### PR TITLE
Allow only Pattern and MemberExpression in assignment target

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -37,7 +37,7 @@ extend interface VariableDeclaration {
 
 ```js
 extend interface AssignmentExpression {
-    left: Pattern | Expression;
+    left: Pattern | MemberExpression;
 }
 ```
 


### PR DESCRIPTION
If I don't miss anything, any other expression can't appear in left side of `AssignmentPattern`.