### PR TITLE
Make ForOfStatement to derive from ForInStatement

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -15,11 +15,8 @@ extend interface Function {
 ## ForOfStatement
 
 ```js
-interface ForOfStatement <: Statement {
+interface ForOfStatement <: ForInStatement {
     type: "ForOfStatement";
-    left: VariableDeclaration |  Expression;
-    right: Expression;
-    body: Statement;
 }
 ```
 


### PR DESCRIPTION
They are pretty similar from parser/traverser perspective, so I don't see a reason for duplicating node structures.

Also allows only `Pattern` and `MemberExpression` as iteration assignment target instead of too generic `Expression` (thanks @michaelficarra).