### PR TITLE
Remove already inherited definitions from ArrowExpression

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -48,11 +48,7 @@ extend interface AssignmentExpression {
 ```js
 interface ArrowExpression <: Function, Expression {
     type: "ArrowExpression";
-    params: [ Pattern ];
-    defaults: [ Expression ];
-    rest: Identifier | null;
     body: BlockStatement | Expression;
-    generator: boolean;
     expression: boolean;
 }
 ```


### PR DESCRIPTION
`params`, `defaults`, `rest` and `generator` already exist in `Function` that `ArrowExpression` inherits from, so there is little sense in redefining those again as something specific to `ArrowExpression`.