### PR TITLE
Add ES6 Property extensions

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -82,7 +82,7 @@ A `yield` expression.
 ## ObjectPattern
 
 ```js
-interface PatternProperty <: Property {
+interface AssignmentProperty <: Property {
     type: "Property"; // inherited
     value: Pattern;
     kind: "init";
@@ -91,7 +91,7 @@ interface PatternProperty <: Property {
 
 interface ObjectPattern <: Pattern {
     type: "ObjectPattern";
-    properties: [ PatternProperty ];
+    properties: [ AssignmentProperty ];
 }
 ```
 

--- a/es6.md
+++ b/es6.md
@@ -39,6 +39,13 @@ extend interface VariableDeclaration {
 extend interface AssignmentExpression {
     left: Pattern | Expression;
 }
+
+extend interface Property {
+    key: Expression;
+    method: boolean;
+    shorthand: boolean;
+    computed: boolean;
+}
 ```
 
 ## ArrowExpression
@@ -75,9 +82,16 @@ A `yield` expression.
 ## ObjectPattern
 
 ```js
+interface PatternProperty <: Property {
+    type: "Property"; // inherited
+    value: Pattern;
+    kind: "init";
+    method: false;
+}
+
 interface ObjectPattern <: Pattern {
     type: "ObjectPattern";
-    properties: [ { key: Literal | Identifier, value: Pattern } ];
+    properties: [ PatternProperty ];
 }
 ```
 


### PR DESCRIPTION
Describes current behavior of both Esprima and Acorn to indicate shorthand property, method shorthand syntax and computed property.

Also, in `ObjectPattern` regular `Property` type is reused but with custom restrictions.