### PR TITLE
Add template literal definitions

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -66,6 +66,41 @@ interface YieldExpression <: Expression {
 
 A `yield` expression.
 
+# Template Literals
+
+## TemplateLiteral
+
+```js
+interface TemplateLiteral <: Expression {
+    type: "TemplateLiteral";
+    quasis: [ TemplateElement ];
+    expressions: [ Expression ];
+}
+```
+
+## TaggedTemplateExpression
+
+```js
+interface TaggedTemplateExpression <: Expression {
+    type: "TaggedTemplateExpression";
+    tag: Expression;
+    quasi: TemplateLiteral;
+}
+```
+
+## TemplateElement
+
+```js
+interface TemplateElement <: Node {
+    type: "TemplateElement";
+    tail: boolean;
+    value: {
+        cooked: string;
+        value: string;
+    }
+}
+```
+
 # Patterns
 
 ## ObjectPattern


### PR DESCRIPTION
Same as #19, both Esprima and Acorn follow this.