### PR TITLE
Revert "Allow only Pattern and MemberExpression in assignment target"

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -37,7 +37,7 @@ extend interface VariableDeclaration {
 
 ```js
 extend interface AssignmentExpression {
-    left: Pattern | MemberExpression;
+    left: Pattern | Expression;
 }
 ```
 


### PR DESCRIPTION
Reverts #20 as having general expression in assignment target is valid in some parsers