### PR TITLE
Add representation for meta properties

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -219,6 +219,16 @@ interface ClassExpression <: Class, Expression {
 }
 ```
 
+## MetaProperty
+
+```js
+interface MetaProperty <: Expression {
+    type: "MetaProperty";
+    meta: Identifier;
+    property: Identifier;
+}
+```
+
 # Modules
 
 ## ImportDeclaration


### PR DESCRIPTION
ECMAScript gets new syntax thing call "meta properties", which is already used as `new.target` and, according to meeting notes, can be used in future in other places as well.

For those cases, we need a new node that (up to discussion) derives from `MemberExpression` but is restricted to having `Identifier` in both `object` (as it's actually a keyword used as `Identifier`) and `property` and can't be `computed` (i.e. `new['target']` is syntax error).
