### PR TITLE
Add import nodes.

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -150,7 +150,7 @@ interface ClassExpression <: Class, Expression {
 
 ## ImportDeclaration
 
-**FIXME:** Esprima's behavior differs from Acorn's and SpiderMonkey's behavior in that `source` is of type `ModuleSpecifier`, but is otherwise a `Literal`.
+**FIXME:** Esprima's behavior differs from Acorn's and SpiderMonkey's behavior in that `source` is of type `ModuleSpecifier`, which is otherwise identical to a `Literal`. See [Esprima bug 1077](https://github.com/jquery/esprima/issues/1077).
 
 ```js
 interface ImportDeclaration <: Declaration {

--- a/es6.md
+++ b/es6.md
@@ -170,13 +170,12 @@ interface ImportSpecifier {
 }
 ```
 
-An imported variable binding, e.g., `{foo}` in `import {foo} from "mod"` or `{foo as bar}` in `import {foo as bar} from "mod"`. The `imported` field represents the imported name from the module. The `local` field represents the bindings imported into the module's global scope. If it is a basic named import, such as in `import {foo} from "mod"`, both `imported` and `local` are equivalent `Identifier` nodes; in this case an `Identifier` node representing `foo`. If it is an aliased import, such as in `import {foo as bar} from "mod"`, the `imported` field is an `Identifier` node representing `foo`, and the `local` field is an `Identifier` node representing `bar`.
+An imported variable binding, e.g., `{foo}` in `import {foo} from "mod"` or `{foo as bar}` in `import {foo as bar} from "mod"`. The `imported` field refers to the name of the export imported from the module. The `local` field refers to the binding imported into the local module scope. If it is a basic named import, such as in `import {foo} from "mod"`, both `imported` and `local` are equivalent `Identifier` nodes; in this case an `Identifier` node representing `foo`. If it is an aliased import, such as in `import {foo as bar} from "mod"`, the `imported` field is an `Identifier` node representing `foo`, and the `local` field is an `Identifier` node representing `bar`.
 
 ## ImportDefaultSpecifier
 
 ```js
 interface ImportDefaultSpecifier {
-    imported: null;
     local: Identifier;
 }
 ```
@@ -187,7 +186,6 @@ A default import specifier, e.g., `foo` in `import foo from "mod.js"`.
 
 ```js
 interface ImportNamespaceSpecifier {
-    imported: null;
     local: Identifier;
 }
 ```

--- a/es6.md
+++ b/es6.md
@@ -145,3 +145,51 @@ interface ClassExpression <: Class, Expression {
     type: "ClassExpression";
 }
 ```
+
+# Modules
+
+## ImportDeclaration
+
+**FIXME:** Esprima's behavior differs from Acorn's and SpiderMonkey's behavior in that `source` is of type `ModuleSpecifier`, but is otherwise a `Literal`.
+
+```js
+interface ImportDeclaration <: Declaration {
+    specifiers: [ ImportSpecifier ];
+    source: Literal; // Or ModuleSpecifier? (Esprima deviation)
+}
+```
+
+An import declaration, e.g., `import foo from "mod";`.
+
+## ImportSpecifier
+
+```js
+interface ImportSpecifier {
+    imported: Identifier;
+    local: Identifier;
+}
+```
+
+An imported variable binding, e.g., `{foo}` in `import {foo} from "mod"` or `{foo as bar}` in `import {foo as bar} from "mod"`. The `imported` field represents the imported name from the module. The `local` field represents the bindings imported into the module's global scope. If it is a basic named import, such as in `import {foo} from "mod"`, both `imported` and `local` are equivalent `Identifier` nodes; in this case an `Identifier` node representing `foo`. If it is an aliased import, such as in `import {foo as bar} from "mod"`, the `imported` field is an `Identifier` node representing `foo`, and the `local` field is an `Identifier` node representing `bar`.
+
+## ImportDefaultSpecifier
+
+```js
+interface ImportDefaultSpecifier {
+    imported: null;
+    local: Identifier;
+}
+```
+
+A default import specifier, e.g., `foo` in `import foo from "mod.js"`.
+
+## ImportNamespaceSpecifier
+
+```js
+interface ImportNamespaceSpecifier {
+    imported: null;
+    local: Identifier;
+}
+```
+
+A namespace import specifier, e.g., `* as foo` in `import * as foo from "mod.js"`.

--- a/es6.md
+++ b/es6.md
@@ -150,12 +150,10 @@ interface ClassExpression <: Class, Expression {
 
 ## ImportDeclaration
 
-**FIXME:** Esprima's behavior differs from Acorn's and SpiderMonkey's behavior in that `source` is of type `ModuleSpecifier`, which is otherwise identical to a `Literal`. See [Esprima bug 1077](https://github.com/jquery/esprima/issues/1077).
-
 ```js
 interface ImportDeclaration <: Declaration {
     specifiers: [ ImportSpecifier ];
-    source: Literal; // Or ModuleSpecifier? (Esprima deviation)
+    source: Literal;
 }
 ```
 


### PR DESCRIPTION
This is to address the import side of things WRT #11 and friends.

Now, WRT ImportDeclaration:

This is the only difference between Acorn/SpiderMonkey and Esprima for ImportDeclarations. I'm personally biased towards using `Literal`, considering I don't otherwise get why it couldn't just be one.

[Acorn](https://github.com/marijnh/acorn/blob/master/acorn.js#L2745-L2759) and [SpiderMonkey](https://hg.mozilla.org/mozilla-central/file/86d2bb8bb1c9/js/src/jsreflect.cpp#l2141) both use `Literal` for node types, while [Esprima](https://github.com/ariya/esprima/blob/harmony/esprima.js#L3635-L3645) uses `ModuleSpecifier`.