### PR TITLE
Flip ArrowExpression to ArrowFunctionExpression with FIXME for SpiderMonkey

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -45,13 +45,13 @@ extend interface Property {
 }
 ```
 
-## ArrowExpression
+## ArrowFunctionExpression
 
-**FIXME:** This describes the SpiderMonkey behavior, which is not currently aligned with the Esprima and Acorn behaviors. See [SpiderMonkey bug 913617](https://bugzilla.mozilla.org/show_bug.cgi?id=913617).
+**FIXME:** This describes the Esprima and Acorn behaviors, which is not currently aligned with the SpiderMonkey behavior. See [SpiderMonkey bug 913617](https://bugzilla.mozilla.org/show_bug.cgi?id=913617).
 
 ```js
-interface ArrowExpression <: Function, Expression {
-    type: "ArrowExpression";
+interface ArrowFunctionExpression <: Function, Expression {
+    type: "ArrowFunctionExpression";
     body: BlockStatement | Expression;
     expression: boolean;
 }


### PR DESCRIPTION
This flips the wording for ArrowFunctionExpression. Considering 2 out of 3 major implementations use ArrowFunctionExpressions, the fixme should be reversed until we achieve resolution.

I can also remove the FIXME as soon as I get word from @dherman .