### PR TITLE
Add type field to RestElement and Assignmentpattern

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -134,6 +134,7 @@ interface ArrayPattern <: Pattern {
 
 ```js
 interface RestElement <: Pattern {
+    type: "RestElement";
     argument: Pattern;
 }
 ```
@@ -142,6 +143,7 @@ interface RestElement <: Pattern {
 
 ```js
 interface AssignmentPattern <: Pattern {
+    type: "AssignmentPattern";
     left: Pattern;
     right: Expression;
 }


### PR DESCRIPTION
This patch adds type field to RestElement and AssignmentPattern since
they can be allocable nodes.

Could you take a look? /cc @RReverser 