### PR TITLE
Restructure experimental docs

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -1,0 +1,3 @@
+These documents specify extensions to the core ESTree AST types to support ES proposals that are at least [stage 0 or above](https://github.com/tc39/ecma262).
+
+**NOTE:** These documents may change at anytime and **should not** be seen as stable.

--- a/experimental/async-functions.md
+++ b/experimental/async-functions.md
@@ -1,7 +1,3 @@
-This document specifies extensions to the core ESTree AST types to support ES proposals that are at least [stage 0 or above](https://github.com/tc39/ecma262).
-
-**NOTE:** This document may change at anytime and **should not** be seen as stable.
-
 # [Async Functions](https://github.com/lukehoban/ecmascript-asyncawait)
 
 ## Function


### PR DESCRIPTION
This should be a non-controversial change. Just need a couple :+1: and I'll merge. I plan on submitting PRs for some upcoming specs (declarators, class property initializers) so this is more scalable.