### PR TITLE
Add `kind`

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -593,10 +593,11 @@ An identifier. Note that an identifier may be an expression or a destructuring p
 interface Literal <: Node, Expression {
     type: "Literal";
     value: string | boolean | null | number | RegExp;
+    kind: "string" | "boolean" | "null" | "number" | "regexp";
 }
 ```
 
-A literal token. Note that a literal can be an expression.
+A literal token. Note that a literal can be an expression. `kind` represents the type of `value`. Examples include `kind === "string"` if `value === "str"` or `kind === "number"` if `value === 2`.
 
 ### RegexLiteral
 

--- a/spec.md
+++ b/spec.md
@@ -593,7 +593,7 @@ An identifier. Note that an identifier may be an expression or a destructuring p
 interface Literal <: Node, Expression {
     type: "Literal";
     value: string | boolean | null | number | RegExp;
-    kind: "string" | "boolean" | "null" | "number" | "regexp";
+    kind: "string" | "boolean" | "null" | "number" | "regex";
 }
 ```
 


### PR DESCRIPTION
Fixes #61.

`kind === "undefined"` was ignored from the original proposal since `undefined` is represented by an Identifier, not a Literal.