### PR TITLE
[RFC] Suggested changes to RegExpLiteral

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -596,10 +596,10 @@ interface Literal <: Node, Expression {
 
 A literal token. Note that a literal can be an expression.
 
-### RegexLiteral
+### RegExpLiteral
 
 ```js
-interface RegexLiteral <: Literal {
+interface RegExpLiteral <: Literal {
   regex: {
     pattern: string;
     flags: string;


### PR DESCRIPTION
The built-in constructor is called `RegExp`, so it seems weirdly inconsistent to call this type `RegexLiteral` instead of `RegExpLiteral`.

I also think we should avoid using a nested, untyped object to represent the pattern and flags of the regular expression, because that sets an unnecessary precedent. Let's either promote that object to be a typed AST node (recall that `Property` nodes were once untyped objects, but the Esprima community found it useful for them to have an actual type), or just flatten the object into multiple fields of the `RegExpLiteral` node (I prefer this, as you can see from this PR).