### PR TITLE
#81 Allow literal as method names in MethodDefinition.

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -220,7 +220,7 @@ interface ClassBody <: Node {
 ```js
 interface MethodDefinition <: Node {
     type: "MethodDefinition";
-    key: Identifier;
+    key: Expression;
     value: FunctionExpression;
     kind: "constructor" | "method" | "get" | "set";
     computed: boolean;


### PR DESCRIPTION
Can use NumericLiteral, StringLiteral and computed property.