### PR TITLE
remove AwaitExpression.all

### DIFF
--- a/experimental/async-functions.md
+++ b/experimental/async-functions.md
@@ -14,6 +14,5 @@ extend interface Function {
 interface AwaitExpression <: Expression {
     type: "AwaitExpression";
     argument: Expression | null;
-    all: boolean;
 }
 ```


### PR DESCRIPTION
Since it was removed https://github.com/tc39/tc39-notes/blob/21a0b0ed8a51995ac94391d7c7674fba110e4044/es7/2015-07/july-30.md#64-advance-async-functions-to-stage-2