### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We've started the process of bringing together various communities using this fo
 # Participating Members
 
 * Dave Herman (Mozilla)
-* Ingvar Stepanyan ([Acorn](https://github.com/marijnh/acorn))
+* Ingvar Stepanyan ([Acorn](https://github.com/ternjs/acorn))
 * Mike Sherov ([Esprima](https://github.com/jquery/esprima))
 * Michael Ficarra ([@michaelficarra](https://github.com/michaelficarra))
 * Sebastian McKenzie ([Babel](https://github.com/babel/babel))


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/marijnh/acorn | https://github.com/ternjs/acorn 
