### PR TITLE
Include Identifier as possible type of MemberExpression.property

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -632,7 +632,7 @@ A logical operator token.
 interface MemberExpression <: Expression, Pattern {
     type: "MemberExpression";
     object: Expression;
-    property: Expression;
+    property: Expression | Identifier;
     computed: boolean;
 }
 ```


### PR DESCRIPTION
I think this is a more preferable way to define the interface? Or, if you're comfortable with it, https://github.com/estree/estree/compare/master...jmm:member-expression-property2.