### PR TITLE
Eliminate redundancy in ES6 AssignmentExpression

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -120,7 +120,7 @@ Spread expression, e.g., `[head, ...iter, tail]`, `f(head, ...iter, ...tail)`.
 
 ```js
 extend interface AssignmentExpression {
-    left: Pattern | MemberExpression;
+    left: Pattern;
 }
 ```
 


### PR DESCRIPTION
Now that MemberExpression implements Pattern (see dfb7d88cc9099a7866417c054a68fd63ec1f086a), it is redundant to say that an assignment's left-hand side can be either a pattern or a member expression.