### PR TITLE
UnaryExpression are always prefix

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -508,7 +508,6 @@ A `function` expression.
 interface UnaryExpression <: Expression {
     type: "UnaryExpression";
     operator: UnaryOperator;
-    prefix: boolean;
     argument: Expression;
 }
 ```


### PR DESCRIPTION
The `prefix` boolean field on UnaryExpressions is redundant because all operators are currently prefix.