### PR TITLE
Fix UpdateExpression.argument

### DIFF
--- a/es5.md
+++ b/es5.md
@@ -531,7 +531,7 @@ A unary operator token.
 interface UpdateExpression <: Expression {
     type: "UpdateExpression";
     operator: UpdateOperator;
-    argument: Expression;
+    argument: Pattern;
     prefix: boolean;
 }
 ```


### PR DESCRIPTION
Couldn't find reasoning for the old one anywhere (backward-compatibility with something?), so I suspect it's just an oversight to include any arbitrary expression.

Thoughts?