### PR TITLE
Add undefined as a possible Literal value

### DIFF
--- a/es5.md
+++ b/es5.md
@@ -111,7 +111,7 @@ An identifier. Note that an identifier may be an expression or a destructuring p
 ```js
 interface Literal <: Expression {
     type: "Literal";
-    value: string | boolean | null | number | RegExp;
+    value: string | boolean | null | number | RegExp | undefined;
 }
 ```
 


### PR DESCRIPTION
`undefined` should be a type of Literal. Currently, there's no mention of `undefined` anywhere in the ESTree spec.

As a result, parsers like Esprima treat `undefined` as an identifier with the name "undefined," because that's the only legal way to express it given the current ESTree type definitions. You can see this behavior in the Esprima demo page here: http://esprima.org/demo/parse.html

I suspect there may be some additional reasoning on why this is the way it is currently (perhaps undefined is not a legal value in this syntax?), but I've been unable to find any references to `undefined` in this repo or associated issues/pull requests, or in Esprima's repo/associated stuff.