### PR TITLE
Add support for template literal revision

### DIFF
--- a/experimental/invalid-tagged-template-escapes.md
+++ b/experimental/invalid-tagged-template-escapes.md
@@ -1,0 +1,12 @@
+# [Template Elements with invalid escape sequences](https://github.com/tc39/proposal-template-literal-revision)
+
+## TemplateElement
+
+```js
+interface TemplateElement <: Node {
+    value: {
+        cooked: string | null;
+        raw: string;
+    };
+}
+```


### PR DESCRIPTION
The [template literal revision](https://github.com/tc39/proposal-template-literal-revision) proposal is at stage 3, and is attempting to reach stage 4 at the TC39 meeting in a few days, but I don't see any indication that ESTree has specified its representation. This adds an experimental extension to support it in the same manner as https://github.com/babel/babylon/pull/274.

One alternative representation would be to introduce an InvalidTemplateElement node for template elements with invalid escape sequences, which would keep the invariant that `TemplateElement.value.cooked` is a string. However, I chose this representation because it keeps the invariant that `TemplateLiteral.quasis` only contains TemplateElements.

This is my first contribution to ESTree, so let me know if there's something I've done incorrectly.