### PR TITLE
MemberExpressions cannot be used as Patterns

### DIFF
--- a/es5.md
+++ b/es5.md
@@ -629,7 +629,7 @@ A logical operator token.
 ### MemberExpression
 
 ```js
-interface MemberExpression <: Expression, Pattern {
+interface MemberExpression <: Expression {
     type: "MemberExpression";
     object: Expression;
     property: Expression;

--- a/es5.md
+++ b/es5.md
@@ -386,7 +386,7 @@ A `for` statement.
 ```js
 interface ForInStatement <: Statement {
     type: "ForInStatement";
-    left: VariableDeclaration |  Pattern;
+    left: VariableDeclaration | Pattern | Expression;
     right: Expression;
     body: Statement;
 }


### PR DESCRIPTION
```js
let {a, b} // << valid pattern
let a.b // << invalid pattern
```