### PR TITLE
Fix es5.md by making it clear that MemberExpression IS a Pattern

### DIFF
--- a/es5.md
+++ b/es5.md
@@ -148,7 +148,7 @@ A complete program source tree.
 ```js
 interface Function <: Node {
     id: Identifier | null;
-    params: [ Pattern ];
+    params: [ Identifier ];
     body: BlockStatement;
 }
 ```
@@ -334,7 +334,7 @@ A `try` statement. If `handler` is `null` then `finalizer` must be a `BlockState
 ```js
 interface CatchClause <: Node {
     type: "CatchClause";
-    param: Pattern;
+    param: Identifier;
     body: BlockStatement;
 }
 ```
@@ -689,7 +689,7 @@ A sequence expression, i.e., a comma-separated sequence of expressions.
 
 # Patterns
 
-Destructuring binding and assignment are not part of ES5, but all binding positions accept `Pattern` to allow for destructuring in ES6. Nevertheless, for ES5, the only `Pattern` subtype is [`Identifier`](#identifier).
+Destructuring binding and assignment are not part of ES5, but all binding positions accept `Pattern` to allow for destructuring in ES6. Nevertheless, for ES5, the only two `Pattern` subtypes are [`Identifier`](#identifier) and [`MemberExpression`](#memberexpression).
 
 ```js
 interface Pattern <: Node { }


### PR DESCRIPTION
… which means that Function.params and CatchClause.param must not be
Patterns.

This is one possible fix for #162.