### PR TITLE
Fix es5.md by making it clear that MemberExpression IS NOT a Pattern

### DIFF
--- a/es5.md
+++ b/es5.md
@@ -386,7 +386,7 @@ A `for` statement.
 ```js
 interface ForInStatement <: Statement {
     type: "ForInStatement";
-    left: VariableDeclaration |  Pattern;
+    left: VariableDeclaration |  Expression;
     right: Expression;
     body: Statement;
 }
@@ -629,7 +629,7 @@ A logical operator token.
 ### MemberExpression
 
 ```js
-interface MemberExpression <: Expression, Pattern {
+interface MemberExpression <: Expression {
     type: "MemberExpression";
     object: Expression;
     property: Expression;


### PR DESCRIPTION
…which means that ForInStatment.left must allow MemberExpression in
addition to Pattern (but, per ES5.1 spec is defined to be any
Expression).

This is another possible fix to #162.