### PR TITLE
Template literal revision

### DIFF
--- a/es2018.md
+++ b/es2018.md
@@ -1,0 +1,11 @@
+This document specifies the extensions to the core ESTree AST types to support the ES2018 grammar.
+
+```js
+extend interface TemplateElement {
+    value: {
+        // `null` when it'd otherwise be an invalid string
+        cooked: string | null;
+        raw: string;
+    };
+}
+```


### PR DESCRIPTION
The [template literal revision](https://tc39.github.io/proposal-template-literal-revision/) recently accepted for ES2018 has no ESTree support. It currently requires that nodes that would otherwise be invalid (e.g. <code>latex \`\newcommand{\unicode}{\textbf{Unicode!}}\`</code>) will have their non-raw component evaluate to `undefined` when they don't exist, but ESTree needs updated to support the possibly non-existent value.