### PR TITLE
Add support for optional catch binding proposal

### DIFF
--- a/experimental/optional-catch-binding.md
+++ b/experimental/optional-catch-binding.md
@@ -1,0 +1,11 @@
+# [Optional catch bindings](https://github.com/tc39/proposal-optional-catch-binding)
+
+#### CatchClause
+
+```js
+interface CatchClause <: Node {
+    type: "CatchClause";
+    param: Pattern | null;
+    body: BlockStatement;
+}
+```


### PR DESCRIPTION
The [optional catch binding proposal](https://github.com/tc39/proposal-optional-catch-binding) is at stage 3. This adds an experimental spec for its AST. The only modification is that `CatchClause.param` is now nullable.