### PR TITLE
Fix arrow function body for `FunctionBody`

### DIFF
--- a/es2015.md
+++ b/es2015.md
@@ -140,7 +140,7 @@ extend interface Property {
 ```js
 interface ArrowFunctionExpression <: Function, Expression {
     type: "ArrowFunctionExpression";
-    body: BlockStatement | Expression;
+    body: FunctionBody | Expression;
     expression: boolean;
 }
 ```


### PR DESCRIPTION
3d0f13b7 changed the body of `FunctionExpression` and `FunctionDeclaration` to `FunctionBody`, but didn't `ArrowFunctionExpression`'s. This PR fixes the body of `ArrowFunctionExpression`, too.

----

> A Directive Prologue is the longest sequence of ExpressionStatements occurring as the initial StatementListItems or ModuleItems of a *FunctionBody*, a ScriptBody, or a ModuleBody and where each ExpressionStatement in the sequence consists entirely of a StringLiteral token followed by a semicolon.
> https://www.ecma-international.org/ecma-262/8.0/#directive-prologue

The body of arrow functions is `{ FunctionBody }` (https://www.ecma-international.org/ecma-262/8.0/#sec-arrow-function-definitions).
