### PR TITLE
Remove reundant Directive

### DIFF
--- a/es5.md
+++ b/es5.md
@@ -137,7 +137,7 @@ these flags `value` will be `null` as the regex can't be represented natively.
 ```js
 interface Program <: Node {
     type: "Program";
-    body: [ Directive | Statement ];
+    body: [ Statement ];
 }
 ```
 


### PR DESCRIPTION
Because a Directive is an ExpressionStatement and an ExpressionStatement is a Statement, this Directive option here is redundant.