### PR TITLE
Remove redundant Directive | Statement instances

### DIFF
--- a/es5.md
+++ b/es5.md
@@ -137,7 +137,7 @@ these flags `value` will be `null` as the regex can't be represented natively.
 ```js
 interface Program <: Node {
     type: "Program";
-    body: [ Directive | Statement ];
+    body: [ Statement ];
 }
 ```
 
@@ -149,7 +149,7 @@ A complete program source tree.
 interface Function <: Node {
     id: Identifier | null;
     params: [ Pattern ];
-    body: FunctionBody;
+    body: BlockStatement;
 }
 ```
 
@@ -195,16 +195,6 @@ interface BlockStatement <: Statement {
 ```
 
 A block statement, i.e., a sequence of statements surrounded by braces.
-
-## FunctionBody
-
-```js
-interface FunctionBody <: BlockStatement {
-    body: [ Directive | Statement ];
-}
-```
-
-The body of a function, which is a block statement that may begin with directives.
 
 ## EmptyStatement
 


### PR DESCRIPTION
Because a Directive is an ExpressionStatement and an ExpressionStatement is a Statement, the use of Directive | Statement option was redundant. This change reverts back to a simpler description that is equivalent to the current one.

This is an alternative to PR #173