### PR TITLE
Make Directive | Statement comments meaningful

### DIFF
--- a/es5.md
+++ b/es5.md
@@ -179,7 +179,7 @@ An expression statement, i.e., a statement consisting of a single expression.
 ```js
 interface Directive <: Node {
     type: "ExpressionStatement";
-    expression: Expression;
+    expression: Literal;
     directive: string;
 }
 ```

--- a/es5.md
+++ b/es5.md
@@ -177,7 +177,9 @@ An expression statement, i.e., a statement consisting of a single expression.
 ## Directive
 
 ```js
-interface Directive <: ExpressionStatement {
+interface Directive <: Node {
+    type: "ExpressionStatement";
+    expression: Expression;
     directive: string;
 }
 ```


### PR DESCRIPTION
Because a Directive is an ExpressionStatement and an ExpressionStatement is a Statement, the use of Directive | Statement option was redundant. This change attempts to capture the intent of the Directive | Statement, by making it clear that while Directive is structurally a subtype of ExpressionStatement, the directive type is not a valid addition to any ExpressionStatement, just ones that are children of a Function or Program.

This is an alternative to PR #172.