### PR TITLE
Properly include SpreadElement in NewExpression arguments.

### DIFF
--- a/es2015.md
+++ b/es2015.md
@@ -112,6 +112,10 @@ extend interface ArrayExpression {
 extend interface CallExpression {
     arguments: [ Expression | SpreadElement ];
 }
+
+extend interface NewExpression {
+    arguments: [ Expression | SpreadElement ];
+}
 ```
 
 Spread expression, e.g., `[head, ...iter, tail]`, `f(head, ...iter, ...tail)`.


### PR DESCRIPTION
Fixes #181

This used to be included indirectly by `CallExpression` because we had

```
interface NewExpression <: CallExpression {
```

but the changes in https://github.com/estree/estree/pull/137 split `NewExpression` into its own `Expression` type and missed that this got lost.