### PR TITLE
Move async-iteration to es2018

### DIFF
--- a/es2018.md
+++ b/es2018.md
@@ -1,5 +1,15 @@
 This document specifies the extensions to the core ESTree AST types to support the ES2018 grammar.
 
+# Statements
+
+```js
+extend interface ForOfStatement {
+  await: boolean;
+}
+```
+
+`for-await-of` statements, e.g., `for await (const x of xs) {`
+
 # Expressions
 
 ```js

--- a/experimental/async-iteration.md
+++ b/experimental/async-iteration.md
@@ -1,9 +1,0 @@
-# [Async Iteration](https://github.com/tc39/proposal-async-iteration)
-
-## ForOfStatement
-
-```js
-extend interface ForOfStatement {
-  await: boolean;
-}
-```


### PR DESCRIPTION
> https://github.com/tc39/proposals/commit/a41dccc91675f41c65dee354c18c19946d6f2f45

Asynchronous Iteration arrived at stage 4.
This PR moves it to es2018.md from the experimental directory.