### PR TITLE
Add optional chaining

### DIFF
--- a/es2020.md
+++ b/es2020.md
@@ -44,7 +44,7 @@ extend interface MemberExpression <: ChainElement {}
 ```
 
 - The `ChainExpression` node is the root of optional chaining.
-- The `ChainExpression` node contains one or more `ChainElement` nodes where are `optional:true`. On the other hand, `ChainElement` nodes where are `optional:true` belong to a `ChainExpression` node.
+- The `ChainExpression` node contains one or more `ChainElement` nodes that are `optional:true`. On the other hand, `ChainElement` nodes that are `optional:true` belong to a `ChainExpression` node.
 - For backward compatibility, if all `ChainElement` nodes of a chain are `optional:false`, the `ChainExpression` node isn't inserted as the root of the chain.
 - Evaluation:
   - The `ChainExpression` node is evaluated to the result of the `expression` property's node.

--- a/es2020.md
+++ b/es2020.md
@@ -27,6 +27,50 @@ interface BigIntLiteral <: Literal {
 
 # Expressions
 
+## ChainingExpression
+
+```js
+interface ChainingExpression extends Expression {
+  type: "ChainingExpression"
+  base: Expression
+  chain: [ Chain ] //< requires one element at least
+}
+
+interface Chain extends Node {
+  optional: boolean
+}
+
+interface MemberChain extends Chain {
+  type: "MemberChain"
+  computed: boolean
+  property: Expression
+}
+
+interface CallChain extends Chain {
+  type: "CallChain"
+  arguments: [ Expression ]
+}
+```
+
+- The `ChainingExpression` node represents the chain of member accesses and
+  function calls. This node is introduced to represent parentheses that
+  `MemberExpression` cannot represent.
+- The `MemberChain` and `CallChain` nodes correspond the existing
+  `MemberExpression` and `CallExpression` nodes, but the `object` and `callee`
+  properties don't exist.
+  The `base` property of the `ChainingExpression` node is the object/callee of
+  the first chain element, and the result of the first chain is the
+  object/callee of the second chain element, and then chaining it to the last
+  chain. If a chain is `optional:true` and the current object/callee is nullish,
+  stop the chaining and the result of the `ChainingExpression` node becomes
+  `undefined`.
+- For backward compatibility, the left of optional chain element is represented
+  by the `MemberExpression` and `CallExpression` nodes as in the past.
+  Therefore, the `base` property of the `ChainingExpression` node can be a
+  `MemberExpression` or `CallExpression` node. And the first chain element is
+  always `optional:true`.
+- See also for examples: https://gist.github.com/mysticatea/f3a87f3e02632797ec59d9b447fdf05e
+
 ## ImportExpression
 
 ```js
@@ -39,7 +83,7 @@ interface ImportExpression <: Expression {
 - `ImportExpression` node represents Dynamic Imports such as `import(source)`.
   The `source` property is the importing source as similar to [ImportDeclaration]
   node, but it can be an arbitrary expression node.
-  
+
 ## LogicalExpression
 
 ```js

--- a/es2020.md
+++ b/es2020.md
@@ -27,49 +27,173 @@ interface BigIntLiteral <: Literal {
 
 # Expressions
 
-## ChainingExpression
+## ChainExpression
 
 ```js
-interface ChainingExpression extends Expression {
-  type: "ChainingExpression"
-  base: Expression
-  chain: [ Chain ] //< requires one element at least
+interface ChainExpression <: Expression {
+  type: "ChainExpression"
+  expression: ChainElement
 }
 
-interface Chain extends Node {
+interface ChainElement <: Node {
   optional: boolean
 }
 
-interface MemberChain extends Chain {
-  type: "MemberChain"
-  computed: boolean
-  property: Expression
-}
+extend interface CallExpression <: ChainElement {}
+extend interface MemberExpression <: ChainElement {}
+```
 
-interface CallChain extends Chain {
-  type: "CallChain"
-  arguments: [ Expression ]
+- The `ChainExpression` node is the root of optional chaining.
+- The `ChainExpression` node contains one or more `ChainElement` nodes where are `optional:true`. On the other hand, `ChainElement` nodes where are `optional:true` belong to a `ChainExpression` node.
+- For backward compatibility, if all `ChainElement` nodes of a chain are `optional:false`, the `ChainExpression` node isn't inserted as the root of the chain.
+- Evaluation:
+  - The `ChainExpression` node is evaluated to the result of the `expression` property's node.
+  - If the `callee|object` property is evaluated to nullish and the `optional` property is `true`, then the node and ancestor nodes are skipped until the closest `ChainExpression` node, and the result of the `ChainExpression` node becomes `undefined`.
+
+<details><summary>For Examples:</summary>
+
+```jsonc
+// obj.aaa.bbb
+{
+  "type": "MemberExpression",
+  "optional": false,
+  "object": {
+    "type": "MemberExpression",
+    "optional": false,
+    "object": { "type": "Identifier", "name": "obj" },
+    "property": { "type": "Identifier", "name": "aaa" }
+  },
+  "property": { "type": "Identifier", "name": "bbb" }
 }
 ```
 
-- The `ChainingExpression` node represents the chain of member accesses and
-  function calls. This node is introduced to represent parentheses that
-  `MemberExpression` cannot represent.
-- The `MemberChain` and `CallChain` nodes correspond the existing
-  `MemberExpression` and `CallExpression` nodes, but the `object` and `callee`
-  properties don't exist.
-  The `base` property of the `ChainingExpression` node is the object/callee of
-  the first chain element, and the result of the first chain is the
-  object/callee of the second chain element, and then chaining it to the last
-  chain. If a chain is `optional:true` and the current object/callee is nullish,
-  stop the chaining and the result of the `ChainingExpression` node becomes
-  `undefined`.
-- For backward compatibility, the left of optional chain element is represented
-  by the `MemberExpression` and `CallExpression` nodes as in the past.
-  Therefore, the `base` property of the `ChainingExpression` node can be a
-  `MemberExpression` or `CallExpression` node. And the first chain element is
-  always `optional:true`.
-- See also for examples: https://gist.github.com/mysticatea/f3a87f3e02632797ec59d9b447fdf05e
+```jsonc
+// obj.aaa?.bbb
+{
+  "type": "ChainExpression",
+  "expression": {
+    "type": "MemberExpression",
+    "optional": true,
+    "object": {
+      "type": "MemberExpression",
+      "optional": false,
+      "object": { "type": "Identifier", "name": "obj" },
+      "property": { "type": "Identifier", "name": "aaa" }
+    },
+    "property": { "type": "Identifier", "name": "bbb" }
+  }
+}
+```
+
+```jsonc
+// obj?.aaa.bbb
+{
+  "type": "ChainExpression",
+  "expression": {
+    "type": "MemberExpression",
+    "optional": false,
+    "object": {
+      "type": "MemberExpression",
+      "optional": true,
+      "object": { "type": "Identifier", "name": "obj" },
+      "property": { "type": "Identifier", "name": "aaa" }
+    },
+    "property": { "type": "Identifier", "name": "bbb" }
+  }
+}
+```
+
+```jsonc
+// obj?.aaa?.bbb
+{
+  "type": "ChainExpression",
+  "expression": {
+    "type": "MemberExpression",
+    "optional": true,
+    "object": {
+      "type": "MemberExpression",
+      "optional": true,
+      "object": { "type": "Identifier", "name": "obj" },
+      "property": { "type": "Identifier", "name": "aaa" }
+    },
+    "property": { "type": "Identifier", "name": "bbb" }
+  }
+}
+```
+
+```jsonc
+// (obj.aaa).bbb
+{
+  "type": "MemberExpression",
+  "optional": false,
+  "object": {
+    "type": "MemberExpression",
+    "optional": false,
+    "object": { "type": "Identifier", "name": "obj" },
+    "property": { "type": "Identifier", "name": "aaa" }
+  },
+  "property": { "type": "Identifier", "name": "bbb" }
+}
+```
+
+```jsonc
+// (obj.aaa)?.bbb
+{
+  "type": "ChainExpression",
+  "expression": {
+    "type": "MemberExpression",
+    "optional": true,
+    "object": {
+      "type": "MemberExpression",
+      "optional": false,
+      "object": { "type": "Identifier", "name": "obj" },
+      "property": { "type": "Identifier", "name": "aaa" }
+    },
+    "property": { "type": "Identifier", "name": "bbb" }
+  }
+}
+```
+
+```jsonc
+// (obj?.aaa).bbb
+{
+  "type": "MemberExpression",
+  "optional": false,
+  "object": {
+    "type": "ChainExpression",
+    "expression": {
+      "type": "MemberExpression",
+      "optional": true,
+      "object": { "type": "Identifier", "name": "obj" },
+      "property": { "type": "Identifier", "name": "aaa" }
+    }
+  },
+  "property": { "type": "Identifier", "name": "bbb" }
+}
+```
+
+```jsonc
+// (obj?.aaa)?.bbb
+{
+  "type": "ChainExpression",
+  "expression": {
+    "type": "MemberExpression",
+    "optional": true,
+    "object": {
+      "type": "ChainExpression",
+      "expression": {
+        "type": "MemberExpression",
+        "optional": true,
+        "object": { "type": "Identifier", "name": "obj" },
+        "property": { "type": "Identifier", "name": "aaa" }
+      }
+    },
+    "property": { "type": "Identifier", "name": "bbb" }
+  }
+}
+```
+
+</details>
 
 ## ImportExpression
 


### PR DESCRIPTION
This is a draft to update `es2020.md` for the TC39 meeting in Dec 2019. The meeting contains the following items on its agenda (https://github.com/tc39/agendas/blob/master/2019/12.md).

- Optional Chaining for Stage 4
- Nullish Coalescing for Stage 4

Therefore, this PR contains the AST proposal of those three syntaxes. If any of them didn't arrive at Stage 4, I will remove those from this PR.

(Because we needed over 2 months to merge a PR in the previous time, I wanted to start discussion earlier.)

----

**Optional Chaining:**

This proposal is inspired by https://github.com/estree/estree/issues/146#issuecomment-365781075. It adds two properties `optional` and `shortCircuited` to two existing nodes `CallExpression` and `MemberExpression`.

The following examples describe how the two properties represent the syntax.

<details>

In the following code blocks, the first comment is the source code and the rest is the AST of the code.

```jsonc
// obj?.aaa?.bbb
{
  "type": "MemberExpression",
  "optional": true,     // If `obj.aaa` was nullish, this node is evaluated to undefined.
  "shortCircuited": true, // If `obj` was nullish, this node is short-circuited.
  "object": {
    "type": "MemberExpression",
    "optional": true,      // If `obj` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "object": { "type": "Identifier", "name": "obj" },
    "property": { "type": "Identifier", "name": "aaa" },
  },
  "property": { "type": "Identifier", "name": "bbb" },
}
```

```jsonc
// obj?.aaa.bbb
{
  "type": "MemberExpression",
  "optional": false,    // If `obj.aaa` was nullish, this node is evaluated to throwing TypeError.
  "shortCircuited": true, // If `obj` was nullish, this node is short-circuited.
  "object": {
    "type": "MemberExpression",
    "optional": true,      // If `obj` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "object": { "type": "Identifier", "name": "obj" },
    "property": { "type": "Identifier", "name": "aaa" },
  },
  "property": { "type": "Identifier", "name": "bbb" },
}
```

```jsonc
// (obj?.aaa)?.bbb
{
  "type": "MemberExpression",
  "optional": true,      // If `obj.aaa` was nullish, this node is evaluated to undefined.
  "shortCircuited": false, // This node isn't short-circuited.
  "object": {
    "type": "MemberExpression",
    "optional": true,      // If `obj` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "object": { "type": "Identifier", "name": "obj" },
    "property": { "type": "Identifier", "name": "aaa" },
  },
  "property": { "type": "Identifier", "name": "bbb" },
}
```

```jsonc
// (obj?.aaa).bbb
{
  "type": "MemberExpression",
  "optional": false,     // If `obj.aaa` was nullish, this node is evaluated to throwing TypeError.
  "shortCircuited": false, // This node isn't short-circuited.
  "object": {
    "type": "MemberExpression",
    "optional": true,      // If `obj` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "object": { "type": "Identifier", "name": "obj" },
    "property": { "type": "Identifier", "name": "aaa" },
  },
  "property": { "type": "Identifier", "name": "bbb" },
}
```

```jsonc
// func?.()?.bbb
{
  "type": "MemberExpression",
  "optional": true,     // If the result of `func()` was nullish, this node is evaluated to undefined.
  "shortCircuited": true, // If `func` was nullish, this node is short-circuited.
  "object": {
    "type": "CallExpression",
    "optional": true,      // If `func` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "callee": { "type": "Identifier", "name": "func" },
    "arguments": [],
  },
  "property": { "type": "Identifier", "name": "bbb" },
}
```

```jsonc
// func?.().bbb
{
  "type": "MemberExpression",
  "optional": false,    // If the result of `func()` was nullish, this node is evaluated to throwing TypeError.
  "shortCircuited": true, // If `func` was nullish, this node is short-circuited.
  "object": {
    "type": "CallExpression",
    "optional": true,      // If `func` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "callee": { "type": "Identifier", "name": "func" },
    "arguments": [],
  },
  "property": { "type": "Identifier", "name": "bbb" },
}
```

```jsonc
// (func?.())?.bbb
{
  "type": "MemberExpression",
  "optional": true,      // If the result of `func()` was nullish, this node is evaluated to undefined.
  "shortCircuited": false, // This node isn't short-circuited.
  "object": {
    "type": "CallExpression",
    "optional": true,      // If `func` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "callee": { "type": "Identifier", "name": "func" },
    "arguments": [],
  },
  "property": { "type": "Identifier", "name": "bbb" },
}
```

```jsonc
// (func?.()).bbb
{
  "type": "MemberExpression",
  "optional": false,     // If the result of `func()` was nullish, this node is evaluated to throwing TypeError.
  "shortCircuited": false, // This node isn't short-circuited.
  "object": {
    "type": "CallExpression",
    "optional": true,      // If `func` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "callee": { "type": "Identifier", "name": "func" },
    "arguments": [],
  },
  "property": { "type": "Identifier", "name": "bbb" },
}
```

```jsonc
// obj?.aaa?.()
{
  "type": "CallExpression",
  "optional": true,     // If `obj.aaa` was nullish, this node is evaluated to undefined.
  "shortCircuited": true, // If `obj` was nullish, this node is short-circuited.
  "callee": {
    "type": "MemberExpression",
    "optional": true,      // If `obj` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "object": { "type": "Identifier", "name": "obj" },
    "property": { "type": "Identifier", "name": "aaa" },
  },
  "arguments": [],
}
```

```jsonc
// obj?.aaa()
{
  "type": "CallExpression",
  "optional": false,    // If `obj.aaa` was nullish, this node is evaluated to throwing TypeError.
  "shortCircuited": true, // If `obj` was nullish, this node is short-circuited.
  "callee": {
    "type": "MemberExpression",
    "optional": true,      // If `obj` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "object": { "type": "Identifier", "name": "obj" },
    "property": { "type": "Identifier", "name": "aaa" },
  },
  "arguments": [],
}
```

```jsonc
// (obj?.aaa)?.()
{
  "type": "CallExpression",
  "optional": true,      // If `obj.aaa` was nullish, this node is evaluated to undefined.
  "shortCircuited": false, // This node isn't short-circuited.
  "callee": {
    "type": "MemberExpression",
    "optional": true,      // If `obj` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "object": { "type": "Identifier", "name": "obj" },
    "property": { "type": "Identifier", "name": "aaa" },
  },
  "arguments": [],
}
```

```jsonc
// (obj?.aaa)()
{
  "type": "CallExpression",
  "optional": false,     // If `obj.aaa` was nullish, this node is evaluated to throwing TypeError.
  "shortCircuited": false, // This node isn't short-circuited.
  "callee": {
    "type": "MemberExpression",
    "optional": true,      // If `obj` was nullish, this node is evaluated to undefined.
    "shortCircuited": false, // This node isn't short-circuited.
    "object": { "type": "Identifier", "name": "obj" },
    "property": { "type": "Identifier", "name": "aaa" },
  },
  "arguments": [],
}
```

</details>

I don't see the advantages of introducing new node types such as `OptionalMemberExpression` because:

- the optional chaining has short-circuit behavior for the right side and parentheses can cancel the short-circuit behavior. Therefore, the related nodes must have the properties of optional chaining regardless of optional or not.
- the new syntax inherits the existing syntax. Even if tools that don't know the new syntax ignored the `optional` and `shortCircuited` properties, I think that the behavior will be not so bad.

**Nullish Coalescing:**

In #203, we look to have a consensus that we should represent the syntax by `LogicalExpression`. This PR follows it.

----

<details>
<summary>This PR closes #146, #153, and #203.</summary>

- fixes #146
- fixes #203
- closes #153

</details>