### PR TITLE
Add `import.meta` to ES2020

### DIFF
--- a/es2015.md
+++ b/es2015.md
@@ -303,6 +303,8 @@ interface MetaProperty <: Expression {
 }
 ```
 
+- `MetaProperty` node represents `new.target` meta property in ES2015. In the future, it will represent other meta properties as well.
+
 # Modules
 
 ## ModuleDeclaration

--- a/es2020.md
+++ b/es2020.md
@@ -37,10 +37,12 @@ interface ImportExpression <: Expression {
 ```
 
 - `ImportExpression` node represents Dynamic Imports such as `import(source)`.
-  The `source` property is the importing source as similar to [ImportExpression]
+  The `source` property is the importing source as similar to [ImportDeclaration]
   node, but it can be an arbitrary expression node.
 
-[ImportExpression]: es2015.md#importdeclaration
+## MetaProperty
+
+Existing [MetaProperty] node represents `import.meta` meta property as well.
 
 # Modules
 
@@ -52,3 +54,6 @@ extend interface ExportAllDeclaration {
 }
 ```
 The `exported` property contains an `Identifier` when a different exported name is specified using `as`, e.g., `export * as foo from "mod";`.
+
+[ImportDeclaration]: es2015.md#importdeclaration
+[MetaProperty]: es2015.md#metaproperty


### PR DESCRIPTION
> https://github.com/tc39/proposals/commit/0c27379ebb525ffebed75584827ce51687af99f8

`import.meta` meta property syntax has arrived at Stage 4 in the 75th TC39 meeting.

This PR brings the syntax into ESTree.
The existing [MetaProperty] node represents `import.meta` meta property as well.

[MetaProperty]: https://github.com/estree/estree/blob/master/es2015.md#metaproperty