### PR TITLE
Governance documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Meanwhile JavaScript is evolving, notably with the upcoming release of ES2015. T
 
 # Discussion
 
-We've started the process of bringing together various communities using this format to move it forward into the ES2015 era and beyond. Feel free to join us! We'll be discussing in the issue tracker and in `#esprima` on Freenode.
+We've started the process of bringing together various communities using this format to move it forward into the ES2015 era and beyond. Feel free to join us! We'll be discussing in the issue tracker.
 
 # AST Descriptor Syntax
 
@@ -20,20 +20,11 @@ extend interface Program {
 }
 ```
 
-# Participating Members
+# ESTree Steering Committee
 
-* Dave Herman (Mozilla)
-* Ingvar Stepanyan, Adrian Heine ([Acorn](https://github.com/acornjs/acorn))
 * [Nicholas C. Zakas](https://github.com/nzakas) ([ESLint](https://github.com/eslint))
-* [Ariya Hidayat](https://github.com/ariya) ([Esprima](https://github.com/jquery/esprima))
-* Michael Ficarra ([@michaelficarra](https://github.com/michaelficarra))
-* [Henry Zhu](https://github.com/hzoo), [Logan Smyth](https://github.com/loganfsmyth), [Daniel Tschinder](https://github.com/danez) ([Babel](https://github.com/babel))
-
-# Inactive Members
-
-* Sebastian McKenzie ([Babel](https://github.com/babel/babel))
-* Kyle Simpson ([@getify](https://github.com/getify))
-* [Mike Sherov](https://github.com/mikesherov) ([Esprima](https://github.com/jquery/esprima))
+* [Ingvar Stepanyan](https://github.com/rreverser) ([Acorn](https://github.com/acornjs/acorn))
+* [Junliang Huang](https://github.com/JLHwung) ([Babel](https://github.com/babel))
 
 # Philosophy
 
@@ -43,3 +34,10 @@ Suggested additions and modifications must follow these guidelines:
 2. **Contextless:** Nodes should not retain any information about their parent. ie. a `FunctionExpression` should not be aware of if it's a concise method. (eg. [#5](https://github.com/estree/estree/issues/5))
 3. **Unique:** Information should not be duplicated. ie. a `kind` property should not be present on `Literal` if the type can be discerned from the `value`. (eg. [#61](https://github.com/estree/estree/issues/61))
 4. **Extensible:** New nodes should be specced to easily allow future spec additions. This means expanding the coverage of node types. ie. `MetaProperty` over `NewTarget` to cover future meta properties. (eg. [#32](https://github.com/estree/estree/pull/32))
+
+
+# Acknowledgements
+
+ESTree has benefited from the contributions of many people over the years. We'd like to thank these folks for their significant contributions to this project:
+
+Sebastian McKenzie ([Babel](https://github.com/babel/babel)), Kyle Simpson ([@getify](https://github.com/getify)), [Mike Sherov](https://github.com/mikesherov) ([Esprima](https://github.com/jquery/esprima)), [Ariya Hidayat](https://github.com/ariya) ([Esprima](https://github.com/jquery/esprima)), Adrian Heine ([Acorn](https://github.com/acornjs/acorn)), [Dave Herman](https://github.com/dherman) (SpiderMonkey), Michael Ficarra ([@michaelficarra](https://github.com/michaelficarra)).

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,55 @@
+# Governance
+
+ESTree is an open source project that depends on contributions from the community. Anyone may contribute to the project at any time by submitting code, participating in discussions, making suggestions, or any other contribution they see fit. This document describes how various types of contributors work within the ESTree project.
+
+## Roles and Responsibilities
+
+### Users
+
+Users are community members who use projects that implement the ESTree specification. Users may become involved with the project and may find themselves becoming Contributors.
+
+### Implementers
+
+Implementers are community members who create or maintain a project that implements the ESTree specification, either through the creation or usage of data structures following the specification. Implementers who continue to engage with the project and its community will often become more and more involved. Such Implementers may find themselves becoming Contributors.
+
+### Contributors
+
+Contributors are community members who contribute in concrete ways to the project, most often in the form of code and/or documentation. Anyone can become a Contributor, and contributions can take many forms. There is no expectation of commitment to the project, no specific skill requirements, and no selection process.
+
+Contributors have read-only access to the ESTree GitHub repository and so submit changes via pull requests. Contributor pull requests have their contribution reviewed and merged by an ESC member. ESC members work with Contributors to review their submission and prepare it for merging.
+
+### Member Projects
+
+Member Projects are projects that implement the ESTree specification and have donated their time to the maintenance and development of the ESTree project. Member Projects may be added or removed through a standard ESC motion (discussed in the next section).
+
+### ESTree Steering Committee (ESC)
+
+The ESLint project is jointly governed by the ESTree Steering Committee (ESC) which is responsible for high-level guidance of the project. The ESC is made up of one representative from each Member Project, and that one representative represents their Member Project's vote in any decision. It's the responsibility of the Member Project representative to drive consensus within the Member Project when decisions about the ESTree project are being made. 
+
+The ESC has final authority over this project including:
+
+* Technical direction
+* Project governance and process (including this policy)
+* Contribution policy
+* GitHub repository hosting
+
+ESC seats are not time-limited. The size of the ESC cannot be larger than five members. This size ensures adequate coverage of important areas of expertise balanced with the ability to make decisions efficiently.
+
+The ESC may add additional members to the ESC, up to the previously mentioned maximum, by a standard ESC motion.
+
+An ESC member may be removed from the ESC by voluntary resignation, and a Member Project may replace its ESC member at any time by informing the other ESC members.
+
+## Consensus Seeking Process
+
+The ESC follows a
+[Consensus Seeking](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making) decision making model.
+
+When a decision has appeared to reach a consensus, an ESC member will ask "Does anyone object?" as a final call for dissent from the consensus.
+
+If a decision cannot reach a consensus, an ESC member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be approved by a majority of the ESC
+or else the discussion will continue. Simple majority wins.
+----
+
+This work is a derivative of [YUI Contributor Model](https://github.com/yui/yui3/wiki/Contributor-Model) and the [Node.js Project Governance Model](https://github.com/nodejs/node/blob/master/GOVERNANCE.md).
+
+This work is licensed under a [Creative Commons Attribution-ShareAlike 2.0 UK: England & Wales License](https://creativecommons.org/licenses/by-sa/2.0/uk/).


### PR DESCRIPTION
## Background

In the beginning, there were several projects who all participated in moving ESTree forward: Acorn, Esprima, ESLint, Babel, JSCS, and SpiderMonkey. Additionally, we benefited from contributions from other smart folks who lent their opinions and insights. In time, though, projects stopped participating for various reasons.

Over the past year, the ESTree project has been struggling to keep up with new syntax changes and decision-making in general. In an effort to fix this, several of the founding members of the project have gotten together to come up with a proposal for how to move forward and make sure that ESTree is getting maintained as effectively as possible.

## Member Projects and the ESC

The Member Projects who have agreed to take on the task of maintaining ESTree going forward are Babel, Acorn, and ESLint. While we may add other projects in the future, we believe that these three projects represent a good cross-section of ESTree use cases and have the bandwidth to donate time towards maintaining the project.

Each Member Project has one representative that participates on the ESTree Steering Committee (ESC) to make decisions. We felt like it was important to formalize how decisions are made so we know who is sharing an opinion and who is making a decision. The ESC members are empowered to drive consensus on their Member Project to make sure their interests are represented in all decisions.

## Feedback Welcome

This is a draft of what we've been talking about privately (only for expediency, not for secrecy). In coming up with this, we did reach out to all of the active members listed on the current README. We moved forward only when we were told they were not interested in participating or if we never heard back. We did not intentionally leave anyone out.