### PR TITLE
add module-attributes

### DIFF
--- a/experimental/module-attributes.md
+++ b/experimental/module-attributes.md
@@ -1,0 +1,41 @@
+# [Module Attributes][proposal-module-attributes]
+
+## Imports
+
+### ImportDeclaration
+
+```js
+extend interface ImportDeclaration {
+    attributes: [ ImportAttribute ];
+}
+```
+
+The `attributes` is non-empty when import attributes present, e.g., `import foo from "./foo.json" with type: "json"`
+
+### ImportAttribute
+
+```js
+interface ImportAttribute <: Node {
+    type: "ImportAttribute";
+    key: Identifier;
+    value: Literal;
+}
+```
+
+An import attribute is an object-like key value pair, e.g., `type: "json"` in `import foo from "./foo.json" with type: "json"`. The `value` must be a string literal, that said, `value.value` is always `string`-type.
+
+
+## Expressions
+
+### ImportExpression
+
+```js
+extend interface ImportExpression {
+    attributes: Expression | null;
+}
+```
+
+The `attributes` property contains an `Expression` when module attributes presents, e.g., `import(jsonModuleName, { type: "json" })`.
+
+[proposal-module-attributes]: https://github.com/tc39/proposal-module-attributes
+


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/add-module-attributes/experimental/module-attributes.md)

Add stage-1 [Module Attributes proposal](https://github.com/tc39/proposal-module-attributes). The `ImportDeclaration` and `ImportAttributes` part also shows how Babel _plans_ to support this feature.

Since many proposals are experimented in Babel in an earlier stage, I think generally we should more proactively get involved in the experimental proposals so we can have more AST shape feedback before it is implemented in Babel. I will add more experimental proposals later.