### PR TITLE
add wavy dot

### DIFF
--- a/experimental/wavy-dot.md
+++ b/experimental/wavy-dot.md
@@ -1,0 +1,17 @@
+# [Wavy Dot](https://github.com/tc39/proposal-wavy-dot)
+
+Extend from the `ChainingExpression` [approach](https://gist.github.com/mysticatea/f3a87f3e02632797ec59d9b447fdf05e).
+
+# Expressions
+
+## ChainingExpression
+```ts
+extend interface Chain <: Node {
+    eventual: boolean
+}
+```
+
+- For backward compatibility, the first chain element must satisfy either `eventual: true` or `optional: true`.
+- `eventual` and `optional` cannot be both `true` but it is subject to change in the future as the proposal is working on optional chaining support.
+
+See also for examples: https://gist.github.com/JLHwung/6ec08a87e4da88874c50788c37d6fdf4


### PR DESCRIPTION
This PR depends on #204.

The draft extends from the `ChainingExpression` approach proposed by the ESLint team. I choose this approach as it is more accessible the the other. I will work the other if we decide to use the `OptionalCallExpression` approach.

Since `a~.b()` and `(a~.b)()` have different semantics, we add `eventual: boolean` to `Chain` instead of `(Member|Call)Expression`. I think this PR can offer perspective on how our decision on #204 will affect other proposal designs.

Note that although the examples contain `?~.`, it should be considered as an experiment of an indeed experimental proposal which has not supported optional chaining yet. Although the optional chaining support can be expected in the near future, I have added a clause that `eventual` and `optional` cannot be both true to align to current proposal.