### PR TITLE
add private-fields-in-in

### DIFF
--- a/experimental/private-fields-in-in.md
+++ b/experimental/private-fields-in-in.md
@@ -5,7 +5,7 @@
 ### BinaryExpression
 
 ```js
-interface BinaryExpression <: Expression {
+extend interface BinaryExpression <: Expression {
     left: Expression | PrivateName;
 }
 ```

--- a/experimental/private-fields-in-in.md
+++ b/experimental/private-fields-in-in.md
@@ -1,0 +1,15 @@
+# [Ergonomic brand checks for Private Fields][proposal-private-fields-in-in]
+
+## Expressions
+
+### BinaryExpression
+
+```js
+interface BinaryExpression <: Expression {
+    left: Expression | PrivateName;
+}
+```
+
+- `left` can be a private name (e.g. `#foo`) when `operator` is `"in"`.
+
+[proposal-private-fields-in-in]: https://github.com/tc39/proposal-private-fields-in-in


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/add-private-fields-in-in/experimental/private-fields-in-in.md)

Added stage-1 [Ergonomic brand checks for Private Fields proposal](https://github.com/tc39/proposal-private-fields-in-in).

This PR depends on #180 where `PrivateName` is defined. Babel also adopts this approach.