### PR TITLE
add record-tuple

### DIFF
--- a/experimental/record-tuple.md
+++ b/experimental/record-tuple.md
@@ -1,0 +1,28 @@
+# [Record & Tuple][proposal-record-tuple]
+
+## Expressions
+
+### RecordExpression
+
+```js
+interface RecordExpression <: Expression {
+    type: "RecordExpression";
+    properties: [ Property | SpreadElement ];
+}
+```
+
+A record expression defines an immutable object, e.g. `#{a: 1}`.
+
+For each element _p_ of `properties`, if _p_ is a `Property`, `p.method` must be `false` and  `p.kind` must be `"init"`.
+
+### TupleExpression
+```js
+interface TupleExpression <: Expression {
+    type: "TupleExpression";
+    elements: [ Expression | SpreadElement ];
+}
+```
+
+A tuple expression defines an immutable array, e.g. `#[1, 2]`. Holes are disallowed in tuple expressions.
+
+[proposal-record-tuple]: https://github.com/tc39/proposal-record-tuple

--- a/experimental/record-tuple.md
+++ b/experimental/record-tuple.md
@@ -7,13 +7,22 @@
 ```js
 interface RecordExpression <: Expression {
     type: "RecordExpression";
-    properties: [ Property | SpreadElement ];
+    properties: [ RecordProperty | SpreadElement ];
 }
 ```
 
 A record expression defines an immutable object, e.g. `#{a: 1}`.
 
-For each element _p_ of `properties`, if _p_ is a `Property`, `p.method` must be `false` and  `p.kind` must be `"init"`.
+#### RecordProperty
+```js
+interface RecordProperty <: Node {
+    type: "RecordProperty";
+    key: Expression;
+    value: Expression;
+    shorthand: boolean;
+    computed: boolean;
+}
+```
 
 ### TupleExpression
 ```js


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/add-record-tuple/experimental/record-tuple.md)

This PR adds stage-1 [Record & Tuple](https://github.com/tc39/proposal-record-tuple) support. It is a close variant of Babel's current implementation. (Babel uses `ObjectProperty` instead)

### Open question
- Should we merge `RecordExpression` and `ObjectExpression` by adding an extra `immutable: boolean` property to `ObjectExpression`? Likewise for `TupleExpression`.