### PR TITLE
add decimal

### DIFF
--- a/experimental/decimal.md
+++ b/experimental/decimal.md
@@ -1,0 +1,25 @@
+# [Decimal][proposal-decimal]
+
+# Literal
+
+```js
+extend interface Literal <: Expression {
+  type: "Literal";
+  value: string | boolean | null | number | RegExp | bigint | bigdecimal
+}
+```
+
+- `value` property can be a `bigdecimal` value to represent decimal literals, e.g. `2.718m`.
+
+## DecimalLiteral
+
+```js
+interface DecimalLiteral <: Literal {
+  decimal: string;
+}
+```
+
+- `decimal` property is the string representation of the `bigdecimal` value. It doesn't include the suffix `m`.
+- In environments that don't support `bigdecimal` values, `value` property will be `null` as the `bigdecimal` value can't be represented natively.
+
+[proposal-decimal]: https://github.com/tc39/proposal-decimal


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/add-decimal/experimental/decimal.md)

This PR adds support on stage-1 [Decimal Proposal](https://github.com/tc39/proposal-decimal).

Note that as of May 2020, TC39 hasn't decided between two competing decimal implementations: `bigdecimal` and `decimal128`. This PR adopts the `bigdecimal` approach. Note that if in the future `decimal128` is chosen instead, we can replace the type annotation of `value` by `decimal128`.

Other than that, whether `bigdecimal` or `decimal128` is chosen should not affect the AST shapes and the new interface name.