### PR TITLE
add class features

### DIFF
--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -7,7 +7,7 @@ This experimental extension covers three class features proposals:
 ## ClassBody
 
 ```js
-extend interface ClassBody <: Node {
+extend interface ClassBody {
     body: [ MethodDefinition | PropertyDefinition ];
 }
 ```
@@ -33,14 +33,12 @@ interface PropertyDefinition <: Node {
 ```js
 extend interface MethodDefinition {
     key: Expression | PrivateName;
-    static: boolean;
     private: boolean;
 }
 ```
 
 - When `private` is `true`, `computed` must be `false`, `key` must be a `PrivateName`, `kind` can not be `"constructor"`.
 - When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateName`.
-- When `static` is `true`, `kind` can not be `"constructor"`.
 
 ### PrivateName
 
@@ -54,7 +52,7 @@ interface PrivateName <: Node {
 A private name refers to private class elements. For a private name `#a`, its `name` is `a`.
 
 ```js
-extend interface MemberExpression <: ChainElement {
+extend interface MemberExpression {
     private: boolean;
     property: Expression | PrivateName;
 }

--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -4,40 +4,42 @@
 This experimental extension covers three class features proposals: 
 [Class Fields], [Static Class Features] and [Private Methods].
 
+## ClassBody
+
+```js
+extend interface ClassBody <: Node {
+    body: [ MethodDefinition | PropertyDefinition ];
+}
+```
+
 ## PropertyDefinition
 
 ```js
 interface PropertyDefinition <: Node {
     type: "PropertyDefinition";
-    key: Expression;
+    key: Expression | PrivateName;
     value: Expression;
     computed: boolean;
     static: boolean;
+    private: boolean;
 }
 ```
 
-## PrivatePropertyDefinition
+- When `private` is `true`, `computed` must be `false` and `key` must be a `PrivateName`.
+- When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateName`.
+
+## MethodDefinition
 
 ```js
-interface PrivatePropertyDefinition <: Node {
-    type: "PrivatePropertyDefinition";
-    key: PrivateName;
-    value: Expression;
+extend interface MethodDefinition <: Node {
+    key: Expression | PrivateName;
     static: boolean;
+    private: boolean;
 }
 ```
 
-## PrivateMethodDefinition
-
-```js
-interface PrivateMethodDefinition <: Node {
-    type: "PrivateMethodDefinition";
-    key: PrivateName;
-    value: FunctionExpression;
-    kind: "method" | "get" | "set";
-    static: boolean;
-}
-```
+- When `private` is `true`, `computed` must be `false`, `key` must be a `PrivateName`, `kind` can not be `constructor`.
+- When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateName`.
 
 ### PrivateName
 
@@ -54,7 +56,7 @@ extend interface MemberExpression {
 
 A private name refers to private class elements. For a private name `#a`, its `id.name` is `a`.
 
-When the property of a member expression is a private name, its `computed` is always `false`.
+When the `property` of a `MemberExpression` is a `PrivateName`, `computed` is always `false`.
 
 [Class Fields]: https://github.com/tc39/proposal-class-fields
 [Static Class Features]: https://github.com/tc39/proposal-static-class-features/

--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -48,15 +48,19 @@ interface PrivateName <: Node {
     type: "PrivateName";
     id: Identifier;
 }
+```
 
-extend interface MemberExpression {
-    property: Expression | PrivateName
+```js
+extend interface MemberExpression <: ChainElement {
+    private: boolean;
+    property: Expression | PrivateName;
 }
 ```
 
 A private name refers to private class elements. For a private name `#a`, its `id.name` is `a`.
 
-When the `property` of a `MemberExpression` is a `PrivateName`, `computed` is always `false`.
+- When `private` is `true`, `property` must be a `PrivateName`, `computed` must be `false`.
+- When `object` is a `Super`, `private` must be `false`.
 
 [Class Fields]: https://github.com/tc39/proposal-class-fields
 [Static Class Features]: https://github.com/tc39/proposal-static-class-features/

--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -17,7 +17,7 @@ extend interface ClassBody {
 ```js
 interface PropertyDefinition <: Node {
     type: "PropertyDefinition";
-    key: Expression | PrivateName;
+    key: Expression | PrivateIdentifier;
     value: Expression | null;
     computed: boolean;
     static: boolean;
@@ -25,26 +25,26 @@ interface PropertyDefinition <: Node {
 }
 ```
 
-- When `private` is `true`, `computed` must be `false` and `key` must be a `PrivateName`.
-- When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateName`.
+- When `private` is `true`, `computed` must be `false` and `key` must be a `PrivateIdentifier`.
+- When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateIdentifier`.
 
 ## MethodDefinition
 
 ```js
 extend interface MethodDefinition {
-    key: Expression | PrivateName;
+    key: Expression | PrivateIdentifier;
     private: boolean;
 }
 ```
 
-- When `private` is `true`, `computed` must be `false`, `key` must be a `PrivateName`, `kind` can not be `"constructor"`.
-- When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateName`.
+- When `private` is `true`, `computed` must be `false`, `key` must be a `PrivateIdentifier`, `kind` can not be `"constructor"`.
+- When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateIdentifier`.
 
-### PrivateName
+### PrivateIdentifier
 
 ```js
-interface PrivateName <: Node {
-    type: "PrivateName";
+interface PrivateIdentifier <: Node {
+    type: "PrivateIdentifier";
     name: string;
 }
 ```
@@ -54,12 +54,12 @@ A private name refers to private class elements. For a private name `#a`, its `n
 ```js
 extend interface MemberExpression {
     private: boolean;
-    property: Expression | PrivateName;
+    property: Expression | PrivateIdentifier;
 }
 ```
 
-- When `private` is `true`, `property` must be a `PrivateName`, `computed` must be `false`.
-- When `private` is `false`, `property` must be an `Expression` and can not be a `PrivateName`.
+- When `private` is `true`, `property` must be a `PrivateIdentifier`, `computed` must be `false`.
+- When `private` is `false`, `property` must be an `Expression` and can not be a `PrivateIdentifier`.
 - When `object` is a `Super`, `private` must be `false`.
 
 [Class Fields]: https://github.com/tc39/proposal-class-fields

--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -18,7 +18,7 @@ extend interface ClassBody <: Node {
 interface PropertyDefinition <: Node {
     type: "PropertyDefinition";
     key: Expression | PrivateName;
-    value: Expression;
+    value: Expression | null;
     computed: boolean;
     static: boolean;
     private: boolean;

--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -38,8 +38,9 @@ extend interface MethodDefinition <: Node {
 }
 ```
 
-- When `private` is `true`, `computed` must be `false`, `key` must be a `PrivateName`, `kind` can not be `constructor`.
+- When `private` is `true`, `computed` must be `false`, `key` must be a `PrivateName`, `kind` can not be `"constructor"`.
 - When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateName`.
+- When `static` is `true`, `kind` can not be `"constructor"`.
 
 ### PrivateName
 
@@ -50,6 +51,8 @@ interface PrivateName <: Node {
 }
 ```
 
+A private name refers to private class elements. For a private name `#a`, its `name` is `a`.
+
 ```js
 extend interface MemberExpression <: ChainElement {
     private: boolean;
@@ -57,9 +60,8 @@ extend interface MemberExpression <: ChainElement {
 }
 ```
 
-A private name refers to private class elements. For a private name `#a`, its `name` is `a`.
-
 - When `private` is `true`, `property` must be a `PrivateName`, `computed` must be `false`.
+- When `private` is `false`, `property` must be an `Expression` and can not be a `PrivateName`.
 - When `object` is a `Super`, `private` must be `false`.
 
 [Class Fields]: https://github.com/tc39/proposal-class-fields

--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -31,7 +31,7 @@ interface PropertyDefinition <: Node {
 ## MethodDefinition
 
 ```js
-extend interface MethodDefinition <: Node {
+extend interface MethodDefinition {
     key: Expression | PrivateName;
     static: boolean;
     private: boolean;

--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -46,7 +46,7 @@ extend interface MethodDefinition <: Node {
 ```js
 interface PrivateName <: Node {
     type: "PrivateName";
-    id: Identifier;
+    name: string;
 }
 ```
 
@@ -57,7 +57,7 @@ extend interface MemberExpression <: ChainElement {
 }
 ```
 
-A private name refers to private class elements. For a private name `#a`, its `id.name` is `a`.
+A private name refers to private class elements. For a private name `#a`, its `name` is `a`.
 
 - When `private` is `true`, `property` must be a `PrivateName`, `computed` must be `false`.
 - When `object` is a `Super`, `private` must be `false`.

--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -1,0 +1,61 @@
+
+# Class Features
+
+This experimental extension covers three class features proposals: 
+[Class Fields], [Static Class Features] and [Private Methods].
+
+## PropertyDefinition
+
+```js
+interface PropertyDefinition <: Node {
+    type: "PropertyDefinition";
+    key: Expression;
+    value: Expression;
+    computed: boolean;
+    static: boolean;
+}
+```
+
+## PrivatePropertyDefinition
+
+```js
+interface PrivatePropertyDefinition <: Node {
+    type: "PrivatePropertyDefinition";
+    key: PrivateName;
+    value: Expression;
+    static: boolean;
+}
+```
+
+## PrivateMethodDefinition
+
+```js
+interface PrivateMethodDefinition <: Node {
+    type: "PrivateMethodDefinition";
+    key: PrivateName;
+    value: FunctionExpression;
+    kind: "method" | "get" | "set";
+    static: boolean;
+}
+```
+
+### PrivateName
+
+```js
+interface PrivateName <: Node {
+    type: "PrivateName";
+    id: Identifier;
+}
+
+extend interface MemberExpression {
+    property: Expression | PrivateName
+}
+```
+
+A private name refers to private class elements. For a private name `#a`, its `id.name` is `a`.
+
+When the property of a member expression is a private name, its `computed` is always `false`.
+
+[Class Fields]: https://github.com/tc39/proposal-class-fields
+[Static Class Features]: https://github.com/tc39/proposal-static-class-features/
+[Private Methods]: https://github.com/tc39/proposal-private-methods

--- a/experimental/class-features.md
+++ b/experimental/class-features.md
@@ -21,24 +21,20 @@ interface PropertyDefinition <: Node {
     value: Expression | null;
     computed: boolean;
     static: boolean;
-    private: boolean;
 }
 ```
 
-- When `private` is `true`, `computed` must be `false` and `key` must be a `PrivateIdentifier`.
-- When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateIdentifier`.
+- When `key` is a `PrivateIdentifier`, `computed` must be `false`.
 
 ## MethodDefinition
 
 ```js
 extend interface MethodDefinition {
     key: Expression | PrivateIdentifier;
-    private: boolean;
 }
 ```
 
-- When `private` is `true`, `computed` must be `false`, `key` must be a `PrivateIdentifier`, `kind` can not be `"constructor"`.
-- When `private` is `false`, `key` must be an `Expression` and can not be a `PrivateIdentifier`.
+- When `key` is a `PrivateIdentifier`, `computed` must be `false` and `kind` can not be `"constructor"`.
 
 ### PrivateIdentifier
 
@@ -49,18 +45,16 @@ interface PrivateIdentifier <: Node {
 }
 ```
 
-A private name refers to private class elements. For a private name `#a`, its `name` is `a`.
+A private identifier refers to private class elements. For a private name `#a`, its `name` is `a`.
 
 ```js
 extend interface MemberExpression {
-    private: boolean;
     property: Expression | PrivateIdentifier;
 }
 ```
 
-- When `private` is `true`, `property` must be a `PrivateIdentifier`, `computed` must be `false`.
-- When `private` is `false`, `property` must be an `Expression` and can not be a `PrivateIdentifier`.
-- When `object` is a `Super`, `private` must be `false`.
+- When `property` is a `PrivateIdentifier`, `computed` must be `false`.
+- When `object` is a `Super`, `property` can not be a `PrivateIdentifier`.
 
 [Class Fields]: https://github.com/tc39/proposal-class-fields
 [Static Class Features]: https://github.com/tc39/proposal-static-class-features/

--- a/experimental/private-fields-in-in.md
+++ b/experimental/private-fields-in-in.md
@@ -6,10 +6,10 @@
 
 ```js
 extend interface BinaryExpression <: Expression {
-    left: Expression | PrivateName;
+    left: Expression | PrivateIdentifier;
 }
 ```
 
-- `left` can be a private name (e.g. `#foo`) when `operator` is `"in"`.
+- `left` can be a private identifier (e.g. `#foo`) when `operator` is `"in"`.
 
 [proposal-private-fields-in-in]: https://github.com/tc39/proposal-private-fields-in-in


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/add-class-features/experimental/class-features.md)

This PR adds support to three stage-3 class features proposals. It shows Babel's current approach except for the following node type naming differences:

| Babel | This PR |
| --- | --- |
| ClassProperty | PropertyDefinition |
| ClassPrivateProperty | PrivatePropertyDefinition |
| ClassPrivateMethod | PrivateMethodDefinition |

It is named in the `*Definition` pattern, aligning to the `MethodDefinition` defined in `es2015`.

This PR also offers an alternative design of #180. In #180 `PrivateMemberExpression` has been introduced for `MemberExpression[property=PrivateName]` in this PR, which will have impact on #204 given that `this?.#priv` is now supported.

As the class proposals have been out there for quite some time and they are widely adopted in React/TypeScript communities, especially the class fields proposal, I will expect some tools are depending on Babel class features AST. Building consensus based on this approach can minimize the friction supporting new ESTree releases.

Fixes #154
Closes #180  

--- Edits ---
Updated according to review comments. PTAL.