### PR TITLE
add slice annotation

### DIFF
--- a/experimental/slice-notation.md
+++ b/experimental/slice-notation.md
@@ -1,0 +1,16 @@
+# [Slice notation][proposal-slice-notation]
+
+## SliceExpression
+
+```js
+interface SliceExpression <: ChainElement, Expression {
+    type: "SliceExpression";
+    object: Expression;
+    lower: Expression | null;
+    upper: Expression | null;
+}
+```
+
+A slice expression, e.g. `arr[0:1]`.
+
+[proposal-slice-notation]: https://github.com/tc39/proposal-slice-notation


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/slice-notation/experimental/slice-notation.md)

This PR adds stage-1 [Slice notation] support.

[Slice notation]: https://github.com/tc39/proposal-slice-notation

Note for reviewer: A minimal spec text is recently drafted: some README examples may not reflect on these changes.