### PR TITLE
move logical assignment to ES2021

### DIFF
--- a/es2021.md
+++ b/es2021.md
@@ -1,8 +1,8 @@
-# [Logical Assignment Operators][proposal-logical-assignment]
+This document specifies the extensions to the core ESTree AST types to support the ES2021 grammar.
 
-## Expressions
+# Expressions
 
-### AssignmentOperator
+## AssignmentOperator
 
 ```js
 extend enum AssignmentOperator {
@@ -12,6 +12,7 @@ extend enum AssignmentOperator {
 
 - [AssignmentExpression] node has short-circuiting behavior if the `operator`
   property is any of `"||="`,`"&&="`, and `"??="`.
+- See [Logical Assignment Operators][proposal-logical-assignment] for details.
 
 [proposal-logical-assignment]: https://github.com/tc39/proposal-logical-assignment
 [AssignmentExpression]: ../es5.md#AssignmentExpression


### PR DESCRIPTION
This PR moves `experimental/logical-assignment-operators` to `es2021` because that has arrived at Stage 4 (https://github.com/tc39/proposals/blob/master/finished-proposals.md).