### PR TITLE
added await.ops

### DIFF
--- a/experimental/await-ops.md
+++ b/experimental/await-ops.md
@@ -3,10 +3,8 @@
 ## AwaitExpression
 
 ```js
-interface AwaitExpression <: Expression {
-    type: "AwaitExpression";
-    argument: Expression;
-    operation: Identifier | null
+extend interface AwaitExpression {
+    operation: Identifier | null // operation.name should be one of the following : 'all', 'race', 'allSettled' and 'any'
 }
 ```
 

--- a/experimental/await-ops.md
+++ b/experimental/await-ops.md
@@ -6,7 +6,7 @@
 interface AwaitExpression <: Expression {
     type: "AwaitExpression";
     argument: Expression;
-    operation: "all" | "any" | "race" | "allSettled" | undefined
+    operation: Identifier | null
 }
 ```
 

--- a/experimental/await-ops.md
+++ b/experimental/await-ops.md
@@ -1,0 +1,22 @@
+# [Await.ops](https://github.com/tc39/proposal-await.ops)
+
+## AwaitExpression
+
+```js
+interface AwaitExpression <: Expression {
+    type: "AwaitExpression";
+    argument: Expression;
+    operation: "all" | "any" | "race" | "allSettled" | undefined
+}
+```
+
+eg :
+
+```js
+async function fn() {
+    await [];
+    await.all [];
+    await.race [];
+    await.allSettled [];
+}
+```


### PR DESCRIPTION
Added [await.ops](https://github.com/tc39/proposal-await.ops) (`stage-0`) to `experiment`

**Question to reviewers** : 
Should it be just as addition to existing `AwaitExpression`

```js
interface AwaitExpression <: Expression {
    operation: "all" | "any" | "race" | "allSettled" | undefined
}
```
or the full one that is currently being implemented.