### PR TITLE
Introduce "stage3" vs. "experimental" distinction

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -1,3 +1,5 @@
-These documents specify extensions to the core ESTree AST types to support ES proposals that are at least [stage 0 or above](https://github.com/tc39/ecma262).
+These documents specify extensions to the core ESTree AST types to support ES
+proposals that are in [stages 0, 1 & 2](https://github.com/tc39/proposals).
 
-**NOTE:** These documents may change at anytime and **should not** be seen as stable.
+**NOTE:** These documents may change at anytime and **should not** be seen as
+stable.

--- a/stage3/README.md
+++ b/stage3/README.md
@@ -1,0 +1,6 @@
+These documents specify extensions to the core ESTree AST types to support ES
+proposals that are at [stage 3](https://github.com/tc39/proposals#stage-3).
+
+**NOTE:** Concensus has been reached on the AST shapes and they can largerly be
+considered stable for implementers. The shape will only change if the spec
+undergoes significant changes from stage 3 to stage 4.


### PR DESCRIPTION
Following https://github.com/estree/estree/issues/240#issuecomment-778168995, this promotes the currently "experimental" class features AST specification in to the root.