### PR TITLE
Promote class-features from "experimental" to "stage3"

### DIFF
--- a/stage3/class-features.md
+++ b/stage3/class-features.md
@@ -1,7 +1,6 @@
+# Classes
 
-# Class Features
-
-This experimental extension covers three class features proposals: 
+These language extensions cover three class features proposals:
 [Class Fields], [Static Class Features] and [Private Methods].
 
 ## ClassBody


### PR DESCRIPTION
Following the introduction of the "stage3" distinction in #241, this PR promotes class-features from "experimental" to "stage3".