### PR TITLE
remove StaticBlock number constraint

### DIFF
--- a/experimental/class-static-block.md
+++ b/experimental/class-static-block.md
@@ -7,7 +7,6 @@ extend interface ClassBody {
     body: [ MethodDefinition | PropertyDefinition | StaticBlock ];
 }
 ```
-- `body` has at most one `StaticBlock`.
 
 ## StaticBlock
 


### PR DESCRIPTION
Per https://github.com/tc39/proposal-class-static-block/pull/38, a class can have multiple static blocks.