### PR TITLE
added missing semicolons in ES2020

### DIFF
--- a/es2020.md
+++ b/es2020.md
@@ -31,15 +31,16 @@ interface BigIntLiteral <: Literal {
 
 ```js
 interface ChainExpression <: Expression {
-  type: "ChainExpression"
-  expression: ChainElement
+  type: "ChainExpression";
+  expression: ChainElement;
 }
 
 interface ChainElement <: Node {
-  optional: boolean
+  optional: boolean;
 }
 
 extend interface CallExpression <: ChainElement {}
+
 extend interface MemberExpression <: ChainElement {}
 ```
 


### PR DESCRIPTION
Minor changes to help with parsing. The other declarations all have semi-colons at the end of the fields and a blank line between types.