### PR TITLE
Add ES2022 normative change

### DIFF
--- a/es2022.md
+++ b/es2022.md
@@ -114,6 +114,16 @@ extend interface ExportSpecifier <: ModuleSpecifier {
 
 If `exported`/`local` is `Literal`, `exported.value`/`local.value` must be a string without lone surrogate.
 
+### ExportAllDeclaration
+
+```js
+extends interface ExportAllDeclaration {
+    exported: Identifier | Literal | null
+}
+```
+
+If `exported` is `Literal`, `exported.value` must be a string without lone surrogate.
+
 [class fields]: https://github.com/tc39/proposal-class-fields
 [static class features]: https://github.com/tc39/proposal-static-class-features/
 [private methods]: https://github.com/tc39/proposal-private-methods

--- a/es2022.md
+++ b/es2022.md
@@ -83,6 +83,33 @@ extend interface BinaryExpression <: Expression {
 - `left` can be a private identifier (e.g. `#foo`) when `operator` is `"in"`.
 - See [Ergonomic brand checks for Private Fields][proposal-private-fields-in-in] for details.
 
+# Modules
+
+See https://github.com/tc39/ecma262/pull/2154 for more details.
+
+## Imports
+
+### ImportSpecifier
+
+```js
+extend interface ImportSpecifier <: ModuleSpecifier {
+    imported: Identifier | Literal;
+}
+```
+
+## Exports
+
+### ExportSpecifier
+
+```js
+extend interface ExportSpecifier <: ModuleSpecifier {
+    local: Identifier | Literal;
+    exported: Identifier | Literal;
+}
+```
+
+`exported` and `local` can be `Literal` only if the `source` of the `ExportNamedDeclaration` of the parent of this node is not `null`. e.g. `export { "foo" as "foo"} from "mod"` is valid, `export { "foo" as "foo"}` is invalid.
+
 [class fields]: https://github.com/tc39/proposal-class-fields
 [static class features]: https://github.com/tc39/proposal-static-class-features/
 [private methods]: https://github.com/tc39/proposal-private-methods

--- a/es2022.md
+++ b/es2022.md
@@ -97,6 +97,8 @@ extend interface ImportSpecifier <: ModuleSpecifier {
 }
 ```
 
+If `imported` is a `Literal`, `imported.value` must be a string without lone surrogate.
+
 ## Exports
 
 ### ExportSpecifier
@@ -109,6 +111,8 @@ extend interface ExportSpecifier <: ModuleSpecifier {
 ```
 
 `exported` and `local` can be `Literal` only if the `source` of the `ExportNamedDeclaration` of the parent of this node is not `null`. e.g. `export { "foo" as "foo"} from "mod"` is valid, `export { "foo" as "foo"}` is invalid.
+
+If `exported`/`local` is `Literal`, `exported.value`/`local.value` must be a string without lone surrogate.
 
 [class fields]: https://github.com/tc39/proposal-class-fields
 [static class features]: https://github.com/tc39/proposal-static-class-features/

--- a/es2022.md
+++ b/es2022.md
@@ -110,7 +110,7 @@ extend interface ExportSpecifier <: ModuleSpecifier {
 }
 ```
 
-`exported` and `local` can be `Literal` only if the `source` of the `ExportNamedDeclaration` of the parent of this node is not `null`. e.g. `export { "foo" as "foo"} from "mod"` is valid, `export { "foo" as "foo"}` is invalid.
+`local` can be `Literal` only if the `source` of the `ExportNamedDeclaration` of the parent of this node is not `null`. e.g. `export { "foo" as "foo" } from "mod"` is valid, `export { "foo" as "foo" }` is invalid.
 
 If `exported`/`local` is `Literal`, `exported.value`/`local.value` must be a string without lone surrogate.
 

--- a/es2022.md
+++ b/es2022.md
@@ -85,7 +85,7 @@ extend interface BinaryExpression <: Expression {
 
 # Modules
 
-See https://github.com/tc39/ecma262/pull/2154 for more details.
+See [Arbitrary module namespace identifier names] for more details.
 
 ## Imports
 
@@ -115,3 +115,4 @@ extend interface ExportSpecifier <: ModuleSpecifier {
 [private methods]: https://github.com/tc39/proposal-private-methods
 [proposal-private-fields-in-in]: https://github.com/tc39/proposal-private-fields-in-in
 [static initialization blocks]: https://github.com/tc39/proposal-class-static-block
+[arbitrary module namespace identifier names]: https://github.com/tc39/ecma262/pull/2154


### PR DESCRIPTION
https://github.com/tc39/ecma262/pull/2154 has been merged to ECMAScript. It will be included in ES2022.

So we should add it to estree spec.

Fixes #270 