### PR TITLE
Fixes Typo (extends -> extend)

### DIFF
--- a/es2022.md
+++ b/es2022.md
@@ -117,7 +117,7 @@ If `exported`/`local` is `Literal`, `exported.value`/`local.value` must be a str
 ### ExportAllDeclaration
 
 ```js
-extends interface ExportAllDeclaration {
+extend interface ExportAllDeclaration {
     exported: Identifier | Literal | null
 }
 ```


### PR DESCRIPTION
I came across this by chance during an automatic merging of the spec files.