### PR TITLE
Align decorators to 2021-12 spec

### DIFF
--- a/experimental/decorators.md
+++ b/experimental/decorators.md
@@ -28,6 +28,14 @@ extend interface Class {
 }
 ```
 
+## ClassBody
+
+```js
+extend interface ClassBody {
+    body: [ MethodDefinition | PropertyDefinition | StaticBlock | AccessorProperty ];
+}
+```
+
 ## MethodDefinition
 ```js
 extend interface MethodDefinition {

--- a/experimental/decorators.md
+++ b/experimental/decorators.md
@@ -1,4 +1,4 @@
-# [Decorators](https://github.com/wycats/javascript-decorators)
+# [Decorators](https://github.com/tc39/proposal-decorators)
 
 ## Decorator
 
@@ -9,18 +9,36 @@ interface Decorator <: Node {
 }
 ```
 
-## Used
+## AccessorProperty
+```js
+interface AccessorProperty <: Node {
+    type: "AccessorProperty";
+    key: Expression | PrivateIdentifier;
+    value: Expression | null;
+    computed: boolean;
+    static: boolean;
+    decorators: [ Decorator ];
+}
+```
 
+## Class
+```js
+extend interface Class {
+    decorators: [ Decorator ];
+}
+```
+
+## MethodDefinition
 ```js
 extend interface MethodDefinition {
     decorators: [ Decorator ];
 }
+```
 
-extend interface Property {
-    decorators: [ Decorator ];
-}
+## PropertyDefinition
 
-extend interface Class {
+```js
+extend interface PropertyDefinition {
     decorators: [ Decorator ];
 }
 ```


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/decorators/experimental/decorators.md)

This PR aligns the decorators experimental AST to the latest proposal, which is asking for stage 3 advancement in March. The AST design is based on Babel's [current implementation](https://github.com/babel/babel/pull/13827).

[Decorators]: https://github.com/tc39/proposal-decorators