### PR TITLE
Add missing "local" field

### DIFF
--- a/es2015.md
+++ b/es2015.md
@@ -343,6 +343,7 @@ An import declaration, e.g., `import foo from "mod";`.
 interface ImportSpecifier <: ModuleSpecifier {
     type: "ImportSpecifier";
     imported: Identifier;
+    local: Identifier;
 }
 ```
 
@@ -391,6 +392,7 @@ _Note: Having `declaration` populated with non-empty `specifiers` or non-null `s
 interface ExportSpecifier <: ModuleSpecifier {
     type: "ExportSpecifier";
     exported: Identifier;
+    local: Identifier;
 }
 ```
 


### PR DESCRIPTION
The description for ImportSpecifier and ExportSpecifier both refer to
a field named "local", which does not appear in either of the
preceding type definitions.