### PR TITLE
Fix inconsistent LogicalOperator extension

### DIFF
--- a/es2020.md
+++ b/es2020.md
@@ -213,7 +213,7 @@ interface ImportExpression <: Expression {
 
 ```js
 extend enum LogicalOperator {
-    "||" | "&&" | "??"
+    "??"
 }
 ```
 


### PR DESCRIPTION
Remove values already listed in the base enum, as all other enum extensions only include new values.

LogicalOperator before this PR:
https://github.com/estree/estree/blob/93648300e3e69cb3c13bb0afb61184f3693ae6aa/es5.md?plain=1#L644-L646

https://github.com/estree/estree/blob/93648300e3e69cb3c13bb0afb61184f3693ae6aa/es2020.md?plain=1#L215-L217

AssignmentOperator, for comparison:
https://github.com/estree/estree/blob/93648300e3e69cb3c13bb0afb61184f3693ae6aa/es5.md?plain=1#L619-L623

https://github.com/estree/estree/blob/93648300e3e69cb3c13bb0afb61184f3693ae6aa/es2016.md?plain=1#L12-L14

https://github.com/estree/estree/blob/93648300e3e69cb3c13bb0afb61184f3693ae6aa/es2021.md?plain=1#L8-L10