### PR TITLE
rename ModuleDeclaration mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ time of writing, 'es2015.md' contained a description of `Program` as seen below
 ```js
 extend interface Program {
     sourceType: "script" | "module";
-    body: [ Statement | ModuleDeclaration ];
+    body: [ Statement | ImportOrExportDeclaration ];
 }
 ```
 

--- a/es2015.md
+++ b/es2015.md
@@ -27,7 +27,7 @@ This document specifies the extensions to the [core ESTree AST types](es5.md) to
   - [ClassExpression](#classexpression)
   - [MetaProperty](#metaproperty)
 - [Modules](#modules)
-  - [ModuleDeclaration](#moduledeclaration)
+  - [ImportOrExportDeclaration](#importorexportdeclaration)
   - [ModuleSpecifier](#modulespecifier)
   - [Imports](#imports)
     - [ImportDeclaration](#importdeclaration)
@@ -47,7 +47,7 @@ This document specifies the extensions to the [core ESTree AST types](es5.md) to
 ```js
 extend interface Program {
     sourceType: "script" | "module";
-    body: [ Statement | ModuleDeclaration ];
+    body: [ Statement | ImportOrExportDeclaration ];
 }
 ```
 
@@ -305,13 +305,13 @@ interface MetaProperty <: Expression {
 
 # Modules
 
-## ModuleDeclaration
+## ImportOrExportDeclaration
 
 ```js
-interface ModuleDeclaration <: Node { }
+interface ImportOrExportDeclaration <: Node { }
 ```
 
-A module `import` or `export` declaration.
+An `import` or `export` declaration.
 
 ## ModuleSpecifier
 
@@ -328,7 +328,7 @@ A specifier in an import or export declaration.
 ### ImportDeclaration
 
 ```js
-interface ImportDeclaration <: ModuleDeclaration {
+interface ImportDeclaration <: ImportOrExportDeclaration {
     type: "ImportDeclaration";
     specifiers: [ ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier ];
     source: Literal;
@@ -373,7 +373,7 @@ A namespace import specifier, e.g., `* as foo` in `import * as foo from "mod.js"
 ### ExportNamedDeclaration
 
 ```js
-interface ExportNamedDeclaration <: ModuleDeclaration {
+interface ExportNamedDeclaration <: ImportOrExportDeclaration {
     type: "ExportNamedDeclaration";
     declaration: Declaration | null;
     specifiers: [ ExportSpecifier ];
@@ -409,7 +409,7 @@ interface AnonymousDefaultExportedClassDeclaration <: Class {
     id: null;
 }
 
-interface ExportDefaultDeclaration <: ModuleDeclaration {
+interface ExportDefaultDeclaration <: ImportOrExportDeclaration {
     type: "ExportDefaultDeclaration";
     declaration: AnonymousDefaultExportedFunctionDeclaration | FunctionDeclaration | AnonymousDefaultExportedClassDeclaration | ClassDeclaration | Expression;
 }
@@ -420,7 +420,7 @@ An export default declaration, e.g., `export default function () {};` or `export
 ### ExportAllDeclaration
 
 ```js
-interface ExportAllDeclaration <: ModuleDeclaration {
+interface ExportAllDeclaration <: ImportOrExportDeclaration {
     type: "ExportAllDeclaration";
     source: Literal;
 }


### PR DESCRIPTION
In this PR we rename the `ModuleDeclaration` mixin so that it won't collide with the new AST type introduced in the [Module Declarations](https://github.com/tc39/proposal-module-declarations) proposal.

This is an editorial change since the AST structures are not impacted. The name `ImportOrExportDeclaration` is tentative so suggestions are definitely welcome.