### PR TITLE
fix: Clarify the value of the bigint Property

### DIFF
--- a/es2020.md
+++ b/es2020.md
@@ -20,8 +20,7 @@ interface BigIntLiteral <: Literal {
 }
 ```
 
-- `bigint` property is the string representation of the `BigInt` value.
-  It doesn't include the suffix `n`.
+- `bigint` property is the string representation of the `BigInt` value. It must contain only decimal digits and not include numeric separators (`_`) or the suffix `n`.
 - In environments that don't support `BigInt` values, `value` property will be
   `null` as the `BigInt` value can't be represented natively.
 


### PR DESCRIPTION
Clarifies the expectations of the string in the `BigIntLiteral.bigint` property.

Fixes #296