### PR TITLE
Import attributes

### DIFF
--- a/experimental/import-attributes.md
+++ b/experimental/import-attributes.md
@@ -1,0 +1,62 @@
+# [Import Attributes][proposal-import-attributes]
+
+## Imports
+
+### ImportDeclaration
+
+```js
+extend interface ImportDeclaration {
+    attributes: [ ImportAttribute ];
+}
+```
+
+The `attributes` is non-empty when import attributes present, e.g., `import foo from "./foo.json" with { type: "json" }`.
+
+Note: While the spec also supports `assert { type: "json" }`, it was considered legacy and thus not covered here. If you want to support the legacy syntax, please use [Import Assertions](../stage3/import-assertions.md) instead.
+
+### ImportAttribute
+
+```js
+interface ImportAttribute <: Node {
+    type: "ImportAttribute";
+    key: Identifier | Literal;
+    value: Literal;
+}
+```
+
+An import attribute is an object-like key value pair, e.g. `type: "json"` in `import foo from "./foo.json" with { type: "json" }`. The `value` must be a string literal, that said, `value.value` is always `string`-type. If `key` is a `Literal`, it must be a string literal.
+
+## Exports
+
+### ExportNamedDeclaration
+
+```js
+extend interface ExportNamedDeclaration {
+    attributes: [ ImportAttribute ];
+}
+```
+- `attributes` must be an empty array when `source` is `null`.
+
+### ExportAllDeclaration
+
+```js
+extend interface ExportAllDeclaration {
+    attributes: [ ImportAttribute ];
+}
+```
+- `attributes` must be an empty array when `source` is `null`.
+
+## Expressions
+
+### ImportExpression
+
+```js
+extend interface ImportExpression {
+    attributes: Expression | null;
+}
+```
+
+The `attributes` property contains an `Expression` when import attributes presents, e.g., `{ with: { type: "json" } }` in `import(jsonModuleName, { with: { type: "json" } })`.
+
+[proposal-import-attributes]: https://github.com/tc39/proposal-import-attributes
+

--- a/stage3/import-assertions.md
+++ b/stage3/import-assertions.md
@@ -1,5 +1,8 @@
 # [Import Assertions][proposal-import-assertions]
 
+> **Warning**
+> This proposal has been superseded by [Import Attributes](../experimental/import-attributes.md).
+
 ## Imports
 
 ### ImportDeclaration
@@ -56,5 +59,4 @@ extend interface ImportExpression {
 
 The `attributes` property contains an `Expression` when import attributes presents, e.g., `{ assert: { type: "json" } }` in `import(jsonModuleName, { assert: { type: "json" } })`.
 
-[proposal-import-assertions]: https://github.com/tc39/proposal-import-assertions
-
+[proposal-import-assertions]: https://github.com/tc39/proposal-import-attributes/tree/f5ad402cd3d3f82f28b1d1be2bfd567cd26336af


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/import-attributes/experimental/import-attributes.md)

This PR adds [Import Attributes] support. It reflects on Babel's current approach https://github.com/babel/babel/pull/15536. The Import Assertions proposal is superseded by this proposal.

[Import Attributes]: https://github.com/tc39/proposal-import-attributes

/cc @nicolo-ribaudo 