### PR TITLE
add class-method-parameter-decorators

### DIFF
--- a/experimental/class-method-parameter-decorators.md
+++ b/experimental/class-method-parameter-decorators.md
@@ -12,8 +12,7 @@ interface Decorator <: Node {
 ## FunctionExpression
 
 ```js
-interface FunctionExpression <: Function, Expression {
-    type: "FunctionExpression";
+extend interface FunctionExpression {
     params: [ Pattern | Parameter ];
 }
 ```

--- a/experimental/class-method-parameter-decorators.md
+++ b/experimental/class-method-parameter-decorators.md
@@ -1,0 +1,33 @@
+# [Decorators for Class Method and Constructor Parameters][proposal-class-method-parameter-decorators]
+
+## Decorator
+
+```js
+interface Decorator <: Node {
+    type: "Decorator";
+    expression: Expression;
+}
+```
+
+## FunctionExpression
+
+```js
+interface FunctionExpression <: Function, Expression {
+    type: "FunctionExpression";
+    params: [ Pattern | Parameter ];
+}
+```
+
+If `params` contains a `Parameter` node, its parent must be a `MethodDefinition` under a `ClassBody` node.
+
+## Parameter
+
+```js
+interface Parameter <: Node {
+    type: "Parameter";
+    parameter: Pattern;
+    decorators: [ Decorator ];
+}
+```
+
+[proposal-class-method-parameter-decorators]: https://github.com/tc39/proposal-class-method-parameter-decorators

--- a/experimental/class-method-parameter-decorators.md
+++ b/experimental/class-method-parameter-decorators.md
@@ -17,7 +17,7 @@ extend interface FunctionExpression {
 }
 ```
 
-If `params` contains a `Parameter` node, its parent must be a `MethodDefinition` under a `ClassBody` node.
+If `params` contains a `Parameter` node, its parent must be a `MethodDefinition`.
 
 ## Parameter
 


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/class-method-parameter-decorators/experimental/class-method-parameter-decorators.md)

This PR adds [Decorators for Class Method and Constructor Parameters] support, currently Stage 1.

[Decorators for Class Method and Constructor Parameters]: https://github.com/tc39/proposal-class-method-parameter-decorators

Currently Babel has two models for the TS decorated parameter:

```js
constructor(readonly @dec param) {}
// AST of the first param
TSParameterProperty {
  readonly: true,
  parameter: Identifier { name: "param" },
  decorators: [ Decorator ]
}
```

```js
constructor(@dec param) {}
// AST of the first param
Identifier {
  name: "param",
  decorators: [ Decorator ]
}
```

The second approach, adding decorators to all `Pattern` AST, seems to be overkill for me because of the concern on memory and precision: the identifier nodes are virtually everywhere, but only a few of them, as function parameters, can be decorated. So I propose to add a new `Parameter` node as a wrapper around `Pattern` that also offers decorators storage.

If we agree on the proposed AST structure and the tc39 proposal were adopted without dramatic changes, then Babel has to migrate the current TypeScript AST from `Identifier { decorators: [ Decorator ]` to `Parameter` when it becomes a JS-thing.

@bradzacher Since the typescript-estree seems to follow Babel's design here for `TSParameterProperty`, I would like to know your opinion.