### PR TITLE
Add AST definition for the Source Phase Imports proposal

### DIFF
--- a/experimental/import-source-phase.md
+++ b/experimental/import-source-phase.md
@@ -1,0 +1,29 @@
+# [Source Phase Imports][proposal-import-reflection]
+
+## Imports
+
+### ImportDeclaration
+
+```js
+extend interface ImportDeclaration {
+    phase: "source" | null;
+}
+```
+
+`phase` is `"source"` when representing an import in the form `import source X from "X"`.
+
+When `phase` is `"source"`, the `specifiers` must be a length-1 array including `ImportDefaultSpecifier`.
+
+## Expressions
+
+### ImportExpression
+
+```js
+extend interface ImportExpression {
+    phase: "source" | null;
+}
+```
+
+`phase` is `"source"` when representing a dynamic import in the form `import.source("X")`.
+
+[proposal-import-reflection]: https://github.com/tc39/proposal-import-reflection

--- a/experimental/source-phase-imports.md
+++ b/experimental/source-phase-imports.md
@@ -1,4 +1,4 @@
-# [Source Phase Imports][proposal-import-reflection]
+# [Source Phase Imports][proposal-source-phase-imports]
 
 ## Imports
 
@@ -26,4 +26,4 @@ extend interface ImportExpression {
 
 `phase` is `"source"` when representing a dynamic import in the form `import.source("X")`.
 
-[proposal-import-reflection]: https://github.com/tc39/proposal-import-reflection
+[proposal-source-phase-imports]: https://github.com/tc39/proposal-source-phase-imports


### PR DESCRIPTION
The Import Reflection proposal (https://github.com/tc39/proposal-import-reflection/) has been updated to use the following syntax:
- `import source X from "X"`
- `import.source("X")`

It is now part of a bigger set of features, that allow importing different "phases" of a module:
- `import source X from "X"`
- `import instance X from "X"` (which is currently not tracked in any proposal, but it is being considered as part of the intersection between import reflection and https://github.com/tc39/proposal-compartments/blob/master/0-module-and-module-source.md)
- `import defer * as ns from "X"` - https://github.com/tc39/proposal-defer-import-eval/

You can read [this presentation](https://docs.google.com/presentation/d/1F62Jia5erIm6m6nqkm_2pFIlNLOVF0E4ewrVRytSJEs/edit#slide=id.p) for more details.

All these "phases" are not composable, so I chose to represent them in the AST as an enum instead of boolean properties. However, this PR only adds support for `source` since it's the only one introduced by this proposal.

I am on the fence regarding what to do with `import x from "X"`. Should `phase` be `null` since it is the default phase, or should we always set `phase` to a string and thus something like `"full"`/`"evaluation"`?

(PS. The ESTree AST works much better than the Babel AST when trying to define `import.source()` 😄)