### PR TITLE
es5: Correct Property description

### DIFF
--- a/es5.md
+++ b/es5.md
@@ -510,7 +510,7 @@ interface Property <: Node {
 }
 ```
 
-A literal property in an object expression can have either a string or number as its `value`. Ordinary property initializers have a `kind` value `"init"`; getters and setters have the kind values `"get"` and `"set"`, respectively.
+A literal property in an object expression can have either a string or number as its `key`. Ordinary property initializers have a `kind` value `"init"`; getters and setters have the kind values `"get"` and `"set"`, respectively.
 
 ## FunctionExpression
 


### PR DESCRIPTION
The description for `Property` says the value may be either a string or a number.

>A literal property in an object expression can have either a string or number as its `value`.

I think this meant to say `key` instead of `value`. Any expression may be used as the value. The key can be a string or number.

```js
{ 1: 2 + 2 } // { '1': 4 }
{ 'key': 2 + 2 } // { 'key': 4 }
```

This patch updates the description of `Property` to constrain `key` instead of `value`.