### PR TITLE
Align ImportAttribute.key constraint

### DIFF
--- a/experimental/import-attributes.md
+++ b/experimental/import-attributes.md
@@ -24,7 +24,7 @@ interface ImportAttribute <: Node {
 }
 ```
 
-An import attribute is an object-like key value pair, e.g. `type: "json"` in `import foo from "./foo.json" with { type: "json" }`. The `value` must be a string literal, that said, `value.value` is always `string`-type. If `key` is a `Literal`, it must be a string literal.
+An import attribute is an object-like key value pair, e.g. `type: "json"` in `import foo from "./foo.json" with { type: "json" }`. The `value` must be a string literal, that said, `value.value` is always `string`-type. If `key` is a `Literal`, it must be a string or numeric literal.
 
 ## Exports
 


### PR DESCRIPTION
The description of `ImportAttribute` constrains a `key` to strings only.

>If `key` is a `Literal`, it must be a string literal.

The latest spec also allows numeric literals, as are possible in an object literal.

```js
import gadget from 'gadget' with {
  1: 'value1',
  2n: 'value2'
}
```

https://ci.tc39.es/preview/tc39/ecma262/sha/1284bb51257753a50d9b29056486da245e38ac03/#prod-WithEntries

```
WithEntries :
        LiteralPropertyName : StringLiteral
        LiteralPropertyName : StringLiteral , WithEntries
```

```
LiteralPropertyName :
        IdentifierName
        StringLiteral
        NumericLiteral
```

This patch extends the constraint on `ImportAttribute.key` to allow numeric literals.