### PR TITLE
add discard-binding

### DIFF
--- a/experimental/discard-binding.md
+++ b/experimental/discard-binding.md
@@ -2,14 +2,14 @@
 
 # Patterns
 ```js
-interface Void <: Pattern {
-    type: "Void";
+interface VoidPattern <: Pattern {
+    type: "VoidPattern";
 }
 ```
 
-- The `left` of an `AssignmentPattern` must not be `Void`
-- The `argument` of a `RestElement` must not be `Void`
-- If the `id` of a `VariableDeclarator` is `Void`, the kind of the encompassing `VariableDeclaration` must be either `using` or `await using` defined in the [Explicit Resource Managemenr Proposal].
+- The `left` of an `AssignmentPattern` must not be `VoidPattern`
+- The `argument` of a `RestElement` must not be `VoidPattern`
+- If the `id` of a `VariableDeclarator` is `VoidPattern`, the `kind` of the encompassing `VariableDeclaration` must be either `using` or `await using` defined in the [Explicit Resource Management Proposal].
 
 [Explicit Resource Management Proposal]: ../stage3/explicit-resource-management.md
 [proposal-discard-biding]: https://github.com/tc39/proposal-discard-binding

--- a/experimental/discard-binding.md
+++ b/experimental/discard-binding.md
@@ -11,5 +11,5 @@ interface Void <: Pattern {
 - The `argument` of a `RestElement` must not be `Void`
 - If the `id` of a `VariableDeclarator` is `Void`, the kind of the encompassing `VariableDeclaration` must be either `using` or `await using` defined in the [Explicit Resource Managemenr Proposal].
 
-[Explicit Resource Managemenr Proposal]: ../stage3/explicit-resource-management.md
+[Explicit Resource Management Proposal]: ../stage3/explicit-resource-management.md
 [proposal-discard-biding]: https://github.com/tc39/proposal-discard-binding

--- a/experimental/discard-binding.md
+++ b/experimental/discard-binding.md
@@ -1,0 +1,15 @@
+# [`void` Discard Bindings for ECMAScript](proposal-discard-binding)
+
+# Patterns
+```js
+interface Void <: Pattern {
+    type: "Void";
+}
+```
+
+- The `left` of an `AssignmentPattern` must not be `Void`
+- The `argument` of a `RestElement` must not be `Void`
+- If the `id` of a `VariableDeclarator` is `Void`, the kind of the encompassing `VariableDeclaration` must be either `using` or `await using` defined in the [Explicit Resource Managemenr Proposal].
+
+[Explicit Resource Managemenr Proposal]: ../stage3/explicit-resource-management.md
+[proposal-discard-biding]: https://github.com/tc39/proposal-discard-binding


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/discard-binding/experimental/discard-binding.md)

This PR adds [`void` Discard Bindings for ECMAScript] support.

Although `const [, x] = foo` is equivalent to `const [void, x] = foo`. I chose a dedicate AST node `Void` instead of `null` because 1) they have different AST representation, which is important for Babel's feature detection and 2) comments around the `void` token can be attached to this AST node. 

An alternative design will be to avoid extending from `Pattern` but instead extend from the element types of the function parameters, array patterns, object patterns and variable declarators. This will be mostly editorial as the AST shape for end users are not changed, but we can get rid of the clauses where `Void` can not be used. I slightly prefer the current version as `void` is also descended from the Patter production in the proposal spec text.

/cc @Boshen, @JoshuaKGoldberg and @kdy1 since you also maintained ESTree-compatible parsers. Please share if you have any ideas about the AST design.

[`void` Discard Bindings for ECMAScript]: https://github.com/tc39/proposal-discard-binding