### PR TITLE
add defer-import-eval

### DIFF
--- a/stage3/defer-import-eval.md
+++ b/stage3/defer-import-eval.md
@@ -1,0 +1,29 @@
+# [Deferring Module Evaluation][proposal-defer-import-eval]
+
+## Imports
+
+### ImportDeclaration
+
+```js
+extend interface ImportDeclaration {
+    phase: "defer" | null;
+}
+```
+
+`phase` is `"defer"` when representing an import in the form `import defer * as X from "X"`.
+
+When `phase` is `"defer"`, the `specifiers` must be a length-1 array including `ImportNamespaceSpecifier`.
+
+## Expressions
+
+### ImportExpression
+
+```js
+extend interface ImportExpression {
+    phase: "defer" | null;
+}
+```
+
+`phase` is `"defer"` when representing a dynamic import in the form `import.defer("X")`.
+
+[proposal-defer-import-eval]: https://github.com/tc39/proposal-defer-import-eval


### PR DESCRIPTION
## [View Rendered Text](https://github.com/JLHwung/estree/blob/defer-import-eval/stage3/defer-import-eval.md)

This PR adds [Deferring Module Evaluation] support. It shares the same design with the [Source Phase Imports] proposal.

[Deferring Module Evaluation]: https://github.com/tc39/proposal-defer-import-eval
[Source Phase Imports]: https://github.com/estree/estree/blob/2b48e56efc223ea477a45b5e034039934c5791fa/stage3/source-phase-imports.md