### PR TITLE
Mark `attributes` and `decorators` as nullable

### DIFF
--- a/es2025.md
+++ b/es2025.md
@@ -8,7 +8,7 @@ This document specifies the extensions to the core ESTree AST types to support t
 
 ```js
 extend interface ImportDeclaration {
-    attributes: [ ImportAttribute ];
+    attributes: [ ImportAttribute ] | null;
 }
 ```
 

--- a/stage3/decorators.md
+++ b/stage3/decorators.md
@@ -17,14 +17,14 @@ interface AccessorProperty <: Node {
     value: Expression | null;
     computed: boolean;
     static: boolean;
-    decorators: [ Decorator ];
+    decorators: [ Decorator ] | null;
 }
 ```
 
 ## Class
 ```js
 extend interface Class {
-    decorators: [ Decorator ];
+    decorators: [ Decorator ] | null;
 }
 ```
 
@@ -39,7 +39,7 @@ extend interface ClassBody {
 ## MethodDefinition
 ```js
 extend interface MethodDefinition {
-    decorators: [ Decorator ];
+    decorators: [ Decorator ] | null;
 }
 ```
 
@@ -47,6 +47,6 @@ extend interface MethodDefinition {
 
 ```js
 extend interface PropertyDefinition {
-    decorators: [ Decorator ];
+    decorators: [ Decorator ] | null;
 }
 ```


### PR DESCRIPTION
Per https://github.com/estree/estree/issues/328#issuecomment-3172494840, in this PR we mark `attributes` and `decorators` as nullable.