### PR TITLE
mark attributes to be nullable

### DIFF
--- a/es2025.md
+++ b/es2025.md
@@ -32,7 +32,7 @@ An import attribute is an object-like key value pair, e.g. `type: "json"` in `im
 
 ```js
 extend interface ExportNamedDeclaration {
-    attributes: [ ImportAttribute ];
+    attributes: [ ImportAttribute ] | null;
 }
 ```
 - `attributes` must be an empty array when `source` is `null`.
@@ -41,7 +41,7 @@ extend interface ExportNamedDeclaration {
 
 ```js
 extend interface ExportAllDeclaration {
-    attributes: [ ImportAttribute ];
+    attributes: [ ImportAttribute ] | null;
 }
 ```
 


### PR DESCRIPTION
As a follow-up to #329, this PR also marks `attributes` introduced to `ExportNamedDeclaration` and `ExportAllDeclaration` as nullable.